### PR TITLE
Updated dummy unpackers

### DIFF
--- a/Kernel/Formats/Unpacker_registry.C
+++ b/Kernel/Formats/Unpacker_registry.C
@@ -73,6 +73,8 @@ static dsp::Unpacker::Register::Enter<dsp::CPSR2TwoBitCorrection> cpsr2;
 #if HAVE_dummy
 #include "dsp/DummyUnpacker.h"
 static dsp::Unpacker::Register::Enter<dsp::DummyUnpacker> dummy;
+#include "dsp/DummyFourBit.h"
+static dsp::Unpacker::Register::Enter<dsp::DummyFourBit> dummy4;
 #endif
 
 #if HAVE_fadc

--- a/Kernel/Formats/dummy/DummyFourBit.C
+++ b/Kernel/Formats/dummy/DummyFourBit.C
@@ -1,0 +1,31 @@
+/***************************************************************************
+ *
+ *   Copyright (C) 2015 by Erik Madsen (from GUPPIFourBit by P. Demorest)
+ *   Licensed under the Academic Free License version 2.1
+ *
+ ***************************************************************************/
+
+#include "dsp/DummyFourBit.h"
+#include "dsp/BitTable.h"
+
+#include <iostream>
+using namespace std;
+
+dsp::DummyFourBit::DummyFourBit ()
+  : FourBitUnpacker ("DummyFourBit")
+{
+  BitTable* table = new BitTable (4, BitTable::OffsetBinary);
+  table->set_order( BitTable::LeastToMost );
+  set_table( table );
+}
+
+bool dsp::DummyFourBit::matches (const Observation* observation)
+{
+  if (verbose)
+    cerr << "dsp::DummyFourBit::matches"
+      " machine=" << observation->get_machine() <<
+      " nbit=" << observation->get_nbit() << endl;
+
+  return observation->get_machine() == "Dummy"
+    && observation->get_nbit() == 4;
+}

--- a/Kernel/Formats/dummy/DummyUnpacker.C
+++ b/Kernel/Formats/dummy/DummyUnpacker.C
@@ -1,54 +1,29 @@
 /***************************************************************************
  *
- *   Copyright (C) 2010 by Paul Demorest
+ *   Copyright (C) 2015 by Erik Madsen (based on GMRTUnpacker)
  *   Licensed under the Academic Free License version 2.1
  *
  ***************************************************************************/
 
 #include "dsp/DummyUnpacker.h"
-#include "Error.h"
+#include "dsp/BitTable.h"
+
+using namespace std;
 
 //! Constructor
-dsp::DummyUnpacker::DummyUnpacker (const char* name) : Unpacker (name)
+dsp::DummyUnpacker::DummyUnpacker (const char* name)
+  : EightBitUnpacker ("DummyEightBit")
 {
+  set_table( new BitTable (8, BitTable::TwosComplement) );
 }
 
 bool dsp::DummyUnpacker::matches (const Observation* observation)
 {
+  if (verbose)
+    cerr << "dsp::DummyUnpacker::matches machine=" << observation->get_machine()
+         << " nbit=" << observation->get_nbit() << endl;
+
   return observation->get_machine() == "Dummy" 
     && observation->get_nbit() == 8;
-}
-
-/*! The quadrature components must be offset by one */
-unsigned dsp::DummyUnpacker::get_output_offset (unsigned idig) const
-{
-  return idig % 2;
-}
-
-/*! The first two digitizer channels are poln0, the last two are poln1 */
-unsigned dsp::DummyUnpacker::get_output_ipol (unsigned idig) const
-{
-  return idig / 2;
-}
-
-void dsp::DummyUnpacker::unpack ()
-{
-  const uint64_t ndat = input->get_ndat();
-  const unsigned npol = input->get_npol();
-  const unsigned ndim = input->get_ndim();
-  const unsigned nskip = npol * ndim;
-
-  // Simple loop over data, ignoring ordering.
-  // If the incoming data needs to be reordered this
-  // will overestimate the processing speed..
-  const char* from = reinterpret_cast<const char*>(input->get_rawptr());
-  float* into = output->get_datptr(0,0);
-  const uint64_t tot_dat = ndat * npol * ndim;
-  for (unsigned bt=0; bt<tot_dat; bt++) {
-    *into = (float)((signed char) *from);
-    from++;
-    into++;
-  }
-
 }
 

--- a/Kernel/Formats/dummy/Makefile.am
+++ b/Kernel/Formats/dummy/Makefile.am
@@ -1,9 +1,11 @@
 
 noinst_LTLIBRARIES = libdummy.la
 
-nobase_include_HEADERS = dsp/DummyUnpacker.h 
+nobase_include_HEADERS = dsp/DummyUnpacker.h \
+              dsp/DummyFourBit.h 
 
-libdummy_la_SOURCES = DummyUnpacker.C
+libdummy_la_SOURCES = DummyUnpacker.C \
+              DummyFourBit.C
 
 #############################################################################
 

--- a/Kernel/Formats/dummy/dsp/DummyFourBit.h
+++ b/Kernel/Formats/dummy/dsp/DummyFourBit.h
@@ -1,0 +1,30 @@
+//-*-C++-*-
+/***************************************************************************
+ *
+ *   Copyright (C) 2015 by Erik Madsen (from GUPPIFourBit by P. Demorest)
+ *   Licensed under the Academic Free License version 2.1
+ *
+ ***************************************************************************/
+
+#ifndef __DummyFourBit_h
+#define __DummyFourBit_h
+
+#include "dsp/FourBitUnpacker.h"
+
+namespace dsp
+{
+  // Based on GUPPIFourBit
+  class DummyFourBit: public FourBitUnpacker
+  {
+  public:
+
+    //! Constructor initializes bit table
+    DummyFourBit ();
+
+    //! Return true if this unpacker can handle the observation
+    bool matches (const Observation*);
+
+  };
+}
+
+#endif

--- a/Kernel/Formats/dummy/dsp/DummyUnpacker.h
+++ b/Kernel/Formats/dummy/dsp/DummyUnpacker.h
@@ -1,7 +1,7 @@
 //-*-C++-*-
 /***************************************************************************
  *
- *   Copyright (C) 2010 by Paul Demorest
+ *   Copyright (C) 2015 by Erik Madsen (based on GMRTUnpacker)
  *   Licensed under the Academic Free License version 2.1
  *
  ***************************************************************************/
@@ -9,12 +9,12 @@
 #ifndef __DummyUnpacker_h
 #define __DummyUnpacker_h
 
-#include "dsp/HistUnpacker.h"
+#include "dsp/EightBitUnpacker.h"
 
 namespace dsp {
 
-  //! Fake 8-bit unpacker
-  class DummyUnpacker : public Unpacker {
+  //! Simple 8-bit to float unpacker
+  class DummyUnpacker : public EightBitUnpacker {
 
   public:
     
@@ -23,14 +23,8 @@ namespace dsp {
 
    protected:
     
-    //! The unpacking routine
-    virtual void unpack ();
-
     //! Return true if we can convert the Observation
     virtual bool matches (const Observation* observation);
-
-    unsigned get_output_offset (unsigned idig) const;
-    unsigned get_output_ipol (unsigned idig) const;
 
   };
 


### PR DESCRIPTION
I've added a 4-bit dummy unpacker using the existing generic 4-bit unpacker (edited guppi's 4-bit unpacker) and changed the 8-bit dummy unpacker so that it uses the existing generic 8-bit unpacker (edited gmrt's 8-bit unpacker).  Everything appears to compile and work as expected.
