### PR TITLE
A couple of fixes

### DIFF
--- a/Kernel/Classes/ASCIIObservation.C
+++ b/Kernel/Classes/ASCIIObservation.C
@@ -33,7 +33,7 @@ dsp::ASCIIObservation::ASCIIObservation (const char* header)
   required_keys.push_back("NPOL");
   required_keys.push_back("NBIT");
   // NDIM and NCHAN have a default value of 1
-  required_keys.push_back("TSAMP");
+  // TSAMP has a default value of NCHAN/BW  
   required_keys.push_back("UTC_START");
   required_keys.push_back("OBS_OFFSET");
 
@@ -298,8 +298,24 @@ void dsp::ASCIIObservation::load (const char* header)
   // TSAMP
   //
   double sampling_interval=0.0;
-  ascii_header_check (header, "TSAMP", "%lf", &sampling_interval);
-
+  if (ascii_header_check (header, "TSAMP", "%lf", &sampling_interval) < 0)
+  {
+    if (bw > 0)
+    {
+      sampling_interval = scan_nchan / bw;
+      if (verbose)
+        cerr << "dsp::ASCIIObservation::load Setting TSAMP to "
+             << "NCHAN/BW=" << sampling_interval << " us" << endl;
+    }
+    else
+    {
+      sampling_interval = 1.0;
+      if (verbose)
+        cerr << "dsp::ASCIIObservation::load No TSAMP or BW provided, "
+             << "setting TSAMP to 1 us" << endl;
+    }
+  }
+    
   /* IMPORTANT: TSAMP is the sampling period in microseconds */
   sampling_interval *= 1e-6;
 

--- a/Kernel/Classes/BitUnpacker.C
+++ b/Kernel/Classes/BitUnpacker.C
@@ -47,33 +47,47 @@ const dsp::BitTable* dsp::BitUnpacker::get_table () const
 
 void dsp::BitUnpacker::unpack ()
 {
-  const uint64_t   ndat  = input->get_ndat();
+  const uint64_t ndat  = input->get_ndat();
 
   const unsigned nchan = input->get_nchan();
   const unsigned npol  = input->get_npol();
   const unsigned ndim  = input->get_ndim();
+  const unsigned nbit  = input->get_nbit();
 
   const unsigned nskip = npol * nchan * ndim;
   const unsigned fskip = ndim;
 
-  unsigned offset = 0;
+  // Step through the array in small block sizes so that the matrix
+  // transpose (for nchan>1 case) remains cache-friendly.
+  const unsigned blockdat = npol*nchan*ndim > 32 ? npol*nchan*ndim : 32;
+  const unsigned blockbytes = blockdat*npol*nchan*ndim*nbit/8;
 
-  for (unsigned ichan=0; ichan<nchan; ichan++)
+  const unsigned char* iptr = input->get_rawptr();
+
+  for (uint64_t idat=0; idat<ndat; idat+=blockdat, iptr+=blockbytes)
   {
-    for (unsigned ipol=0; ipol<npol; ipol++)
+    unsigned offset = 0;
+    const unsigned ndatblock = (blockdat>(ndat-idat)) ? ndat-idat : blockdat;
+    for (unsigned ichan=0; ichan<nchan; ichan++)
     {
-      for (unsigned idim=0; idim<ndim; idim++)
+      for (unsigned ipol=0; ipol<npol; ipol++)
       {
-	const unsigned char* from = input->get_rawptr() + offset;
-	float* into = output->get_datptr (ichan, ipol) + idim;
-	unsigned long* hist = get_histogram (offset);
- 
+        for (unsigned idim=0; idim<ndim; idim++)
+        {
+          //offset = idim + ipol*ndim + ichan*npol*ndim;
+          //const unsigned char* from = input->get_rawptr() + offset;
+          const unsigned char* from = iptr + offset;
+          float* into = output->get_datptr (ichan, ipol) + ndim*idat + idim;
+          unsigned long* hist = get_histogram (offset);
+   
 #ifdef _DEBUG
-        cerr << "c=" << ichan << " p=" << ipol << " d=" << idim << endl;
+          cerr << "c=" << ichan << " p=" << ipol << " d=" << idim << endl;
 #endif
  
-	unpack (ndat, from, nskip, into, fskip, hist);
-	offset ++;
+          unpack (ndatblock, from, nskip, into, fskip, hist);
+          //unpack (ndat, from, nskip, into, fskip, hist);
+          offset ++;
+        }
       }
     }
   }

--- a/Kernel/Classes/BitUnpacker.C
+++ b/Kernel/Classes/BitUnpacker.C
@@ -60,7 +60,7 @@ void dsp::BitUnpacker::unpack ()
   // Step through the array in small block sizes so that the matrix
   // transpose (for nchan>1 case) remains cache-friendly.
   const unsigned blockdat = npol*nchan*ndim > 32 ? npol*nchan*ndim : 32;
-  const unsigned blockbytes = blockdat*npol*nchan*ndim*nbit/8;
+  const unsigned blockbytes = blockdat*nbit/8;
 
   const unsigned char* iptr = input->get_rawptr();
 

--- a/Kernel/Formats/Unpacker_registry.C
+++ b/Kernel/Formats/Unpacker_registry.C
@@ -73,6 +73,8 @@ static dsp::Unpacker::Register::Enter<dsp::CPSR2TwoBitCorrection> cpsr2;
 #if HAVE_dummy
 #include "dsp/DummyUnpacker.h"
 static dsp::Unpacker::Register::Enter<dsp::DummyUnpacker> dummy;
+#include "dsp/DummyFourBit.h"
+static dsp::Unpacker::Register::Enter<dsp::DummyFourBit> dummy4;
 #endif
 
 #if HAVE_fadc

--- a/Kernel/Formats/dummy/DummyFourBit.C
+++ b/Kernel/Formats/dummy/DummyFourBit.C
@@ -1,0 +1,31 @@
+/***************************************************************************
+ *
+ *   Copyright (C) 2015 by Erik Madsen (from GUPPIFourBit by P. Demorest)
+ *   Licensed under the Academic Free License version 2.1
+ *
+ ***************************************************************************/
+
+#include "dsp/DummyFourBit.h"
+#include "dsp/BitTable.h"
+
+#include <iostream>
+using namespace std;
+
+dsp::DummyFourBit::DummyFourBit ()
+  : FourBitUnpacker ("DummyFourBit")
+{
+  BitTable* table = new BitTable (4, BitTable::OffsetBinary);
+  table->set_order( BitTable::LeastToMost );
+  set_table( table );
+}
+
+bool dsp::DummyFourBit::matches (const Observation* observation)
+{
+  if (verbose)
+    cerr << "dsp::DummyFourBit::matches"
+      " machine=" << observation->get_machine() <<
+      " nbit=" << observation->get_nbit() << endl;
+
+  return observation->get_machine() == "Dummy"
+    && observation->get_nbit() == 4;
+}

--- a/Kernel/Formats/dummy/DummyUnpacker.C
+++ b/Kernel/Formats/dummy/DummyUnpacker.C
@@ -1,54 +1,29 @@
 /***************************************************************************
  *
- *   Copyright (C) 2010 by Paul Demorest
+ *   Copyright (C) 2015 by Erik Madsen (based on GMRTUnpacker)
  *   Licensed under the Academic Free License version 2.1
  *
  ***************************************************************************/
 
 #include "dsp/DummyUnpacker.h"
-#include "Error.h"
+#include "dsp/BitTable.h"
+
+using namespace std;
 
 //! Constructor
-dsp::DummyUnpacker::DummyUnpacker (const char* name) : Unpacker (name)
+dsp::DummyUnpacker::DummyUnpacker (const char* name)
+  : EightBitUnpacker ("DummyEightBit")
 {
+  set_table( new BitTable (8, BitTable::TwosComplement) );
 }
 
 bool dsp::DummyUnpacker::matches (const Observation* observation)
 {
+  if (verbose)
+    cerr << "dsp::DummyUnpacker::matches machine=" << observation->get_machine()
+         << " nbit=" << observation->get_nbit() << endl;
+
   return observation->get_machine() == "Dummy" 
     && observation->get_nbit() == 8;
-}
-
-/*! The quadrature components must be offset by one */
-unsigned dsp::DummyUnpacker::get_output_offset (unsigned idig) const
-{
-  return idig % 2;
-}
-
-/*! The first two digitizer channels are poln0, the last two are poln1 */
-unsigned dsp::DummyUnpacker::get_output_ipol (unsigned idig) const
-{
-  return idig / 2;
-}
-
-void dsp::DummyUnpacker::unpack ()
-{
-  const uint64_t ndat = input->get_ndat();
-  const unsigned npol = input->get_npol();
-  const unsigned ndim = input->get_ndim();
-  const unsigned nskip = npol * ndim;
-
-  // Simple loop over data, ignoring ordering.
-  // If the incoming data needs to be reordered this
-  // will overestimate the processing speed..
-  const char* from = reinterpret_cast<const char*>(input->get_rawptr());
-  float* into = output->get_datptr(0,0);
-  const uint64_t tot_dat = ndat * npol * ndim;
-  for (unsigned bt=0; bt<tot_dat; bt++) {
-    *into = (float)((signed char) *from);
-    from++;
-    into++;
-  }
-
 }
 

--- a/Kernel/Formats/dummy/Makefile.am
+++ b/Kernel/Formats/dummy/Makefile.am
@@ -1,9 +1,11 @@
 
 noinst_LTLIBRARIES = libdummy.la
 
-nobase_include_HEADERS = dsp/DummyUnpacker.h 
+nobase_include_HEADERS = dsp/DummyUnpacker.h \
+              dsp/DummyFourBit.h 
 
-libdummy_la_SOURCES = DummyUnpacker.C
+libdummy_la_SOURCES = DummyUnpacker.C \
+              DummyFourBit.C
 
 #############################################################################
 

--- a/Kernel/Formats/dummy/dsp/DummyFourBit.h
+++ b/Kernel/Formats/dummy/dsp/DummyFourBit.h
@@ -1,0 +1,30 @@
+//-*-C++-*-
+/***************************************************************************
+ *
+ *   Copyright (C) 2015 by Erik Madsen (from GUPPIFourBit by P. Demorest)
+ *   Licensed under the Academic Free License version 2.1
+ *
+ ***************************************************************************/
+
+#ifndef __DummyFourBit_h
+#define __DummyFourBit_h
+
+#include "dsp/FourBitUnpacker.h"
+
+namespace dsp
+{
+  // Based on GUPPIFourBit
+  class DummyFourBit: public FourBitUnpacker
+  {
+  public:
+
+    //! Constructor initializes bit table
+    DummyFourBit ();
+
+    //! Return true if this unpacker can handle the observation
+    bool matches (const Observation*);
+
+  };
+}
+
+#endif

--- a/Kernel/Formats/dummy/dsp/DummyUnpacker.h
+++ b/Kernel/Formats/dummy/dsp/DummyUnpacker.h
@@ -1,7 +1,7 @@
 //-*-C++-*-
 /***************************************************************************
  *
- *   Copyright (C) 2010 by Paul Demorest
+ *   Copyright (C) 2015 by Erik Madsen (based on GMRTUnpacker)
  *   Licensed under the Academic Free License version 2.1
  *
  ***************************************************************************/
@@ -9,12 +9,12 @@
 #ifndef __DummyUnpacker_h
 #define __DummyUnpacker_h
 
-#include "dsp/HistUnpacker.h"
+#include "dsp/EightBitUnpacker.h"
 
 namespace dsp {
 
-  //! Fake 8-bit unpacker
-  class DummyUnpacker : public Unpacker {
+  //! Simple 8-bit to float unpacker
+  class DummyUnpacker : public EightBitUnpacker {
 
   public:
     
@@ -23,14 +23,8 @@ namespace dsp {
 
    protected:
     
-    //! The unpacking routine
-    virtual void unpack ();
-
     //! Return true if we can convert the Observation
     virtual bool matches (const Observation* observation);
-
-    unsigned get_output_offset (unsigned idig) const;
-    unsigned get_output_ipol (unsigned idig) const;
 
   };
 

--- a/Signal/General/FilterbankCUDA.cu
+++ b/Signal/General/FilterbankCUDA.cu
@@ -273,7 +273,7 @@ void CUDA::FilterbankEngine::perform (const dsp::TimeSeries * in, dsp::TimeSerie
         if (out)
         {
           output_ptr = out->get_datptr (ichan*nchan_subband, ipol) + out_offset;
-          output_span = out->get_datptr (ichan*nchan_subband+1, ipol) - out->get_datptr (ichan*nchan_subband, ipol);
+          output_span = out->get_datptr (1, ipol) - out->get_datptr (0, ipol);
 
           const float2* input = cscratch + nfilt_pos;
           unsigned input_stride = freq_res;

--- a/Signal/General/FilterbankCUDA.cu
+++ b/Signal/General/FilterbankCUDA.cu
@@ -113,12 +113,15 @@ void CUDA::FilterbankEngine::setup (dsp::Filterbank* filterbank)
 
   DEBUG("CUDA::FilterbankEngine::setup fwd FFT plan set");
 
+  // if inverse FFT is necessary
   if (freq_res > 1)
   {
-    result = cufftPlan1d (&plan_bwd, freq_res, CUFFT_C2C, nchan_subband);
+    int n[1] = { freq_res };
+    result = cufftPlanMany (&plan_bwd, 1, n, NULL, NULL, NULL, NULL, NULL,
+                            NULL, CUFFT_C2C, nchan_subband);
     if (result != CUFFT_SUCCESS)
-      throw CUFFTError (result, "CUDA::FilterbankEngine::setup", 
-			"cufftPlan1d(plan_bwd)");
+      throw CUFFTError (result, "CUDA::FilterbankEngine::setup",
+            "cufftPlanMany(plan_bwd)");
 
     // optimal performance for CUFFT regarding data layout
     result = cufftSetCompatibilityMode(plan_bwd, CUFFT_COMPATIBILITY_FFTW_PADDING);

--- a/Signal/General/FilterbankCUDA.cu
+++ b/Signal/General/FilterbankCUDA.cu
@@ -117,8 +117,8 @@ void CUDA::FilterbankEngine::setup (dsp::Filterbank* filterbank)
   if (freq_res > 1)
   {
     int n[1] = { freq_res };
-    result = cufftPlanMany (&plan_bwd, 1, n, NULL, NULL, NULL, NULL, NULL,
-                            NULL, CUFFT_C2C, nchan_subband);
+    result = cufftPlanMany (&plan_bwd, 1, n, NULL, 0, 0, NULL, 0, 0,
+                            CUFFT_C2C, nchan_subband);
     if (result != CUFFT_SUCCESS)
       throw CUFFTError (result, "CUDA::FilterbankEngine::setup",
             "cufftPlanMany(plan_bwd)");

--- a/Signal/General/FilterbankCUDA.cu
+++ b/Signal/General/FilterbankCUDA.cu
@@ -100,7 +100,7 @@ void CUDA::FilterbankEngine::setup (dsp::Filterbank* filterbank)
 			"cufftPlan1d(plan_fwd, CUFFT_C2C)");
   }
 
-  result = cufftSetCompatibilityMode(plan_fwd, CUFFT_COMPATIBILITY_NATIVE);
+  result = cufftSetCompatibilityMode(plan_fwd, CUFFT_COMPATIBILITY_FFTW_PADDING);
   if (result != CUFFT_SUCCESS)
     throw CUFFTError (result, "CUDA::FilterbankEngine::setup",
 		      "cufftSetCompatibilityMode(plan_fwd)");
@@ -121,7 +121,7 @@ void CUDA::FilterbankEngine::setup (dsp::Filterbank* filterbank)
 			"cufftPlan1d(plan_bwd)");
 
     // optimal performance for CUFFT regarding data layout
-    result = cufftSetCompatibilityMode(plan_bwd, CUFFT_COMPATIBILITY_NATIVE);
+    result = cufftSetCompatibilityMode(plan_bwd, CUFFT_COMPATIBILITY_FFTW_PADDING);
     if (result != CUFFT_SUCCESS)
       throw CUFFTError (result, "CUDA::FilterbankEngine::setup",
 			"cufftSetCompatibilityMode(plan_bwd)");

--- a/Signal/General/SingleThread.C
+++ b/Signal/General/SingleThread.C
@@ -240,9 +240,6 @@ void dsp::SingleThread::construct () try
     if (config->get_total_nthread() > 1)
       config->input_buffering = false;
 
-    //if (thread_id == 0)
-    //  cudaStreamCreate(manager->get_input_stream_ptr());
-
     int device = config->cuda_device[thread_id];
     cerr << "dspsr: thread " << thread_id
          << " using CUDA device " << device << endl;

--- a/Signal/General/SingleThread.C
+++ b/Signal/General/SingleThread.C
@@ -263,6 +263,8 @@ void dsp::SingleThread::construct () try
       if (Operation::verbose)
         cerr << "SingleThread: unpack on CPU" << endl;
 
+      unpacked->set_memory (new CUDA::PinnedMemory);
+
       TransferCUDA* transfer = new TransferCUDA (stream);
       transfer->set_kind( cudaMemcpyHostToDevice );
       transfer->set_input( unpacked );

--- a/Signal/General/dsp/Filterbank.h
+++ b/Signal/General/dsp/Filterbank.h
@@ -67,6 +67,9 @@ namespace dsp {
     class Engine;
     void set_engine (Engine*);
 
+    void set_d_kernel_gpu_ptr (void** dk_ptr) { d_kernel_gpu_ptr = dk_ptr; }
+    void** get_d_kernel_gpu_ptr () { return d_kernel_gpu_ptr; }
+
   protected:
 
     //! Perform the convolution transformation on the input TimeSeries
@@ -91,6 +94,9 @@ namespace dsp {
 
     //! Interface to alternate processing engine (e.g. GPU)
     Reference::To<Engine> engine;
+    
+    // Points to d_kernel_gpu defined in LoadToFoldConfig
+    void** d_kernel_gpu_ptr;
 
   private:
 

--- a/Signal/General/dsp/FilterbankCUDA.h
+++ b/Signal/General/dsp/FilterbankCUDA.h
@@ -35,8 +35,6 @@ namespace CUDA
   //! Discrete convolution filterbank step implemented using CUDA streams
   class FilterbankEngine : public dsp::Filterbank::Engine
   {
-    unsigned nstream;
-
   public:
 
     //! Default Constructor

--- a/Signal/General/dsp/FilterbankCUDA.h
+++ b/Signal/General/dsp/FilterbankCUDA.h
@@ -35,6 +35,8 @@ namespace CUDA
   //! Discrete convolution filterbank step implemented using CUDA streams
   class FilterbankEngine : public dsp::Filterbank::Engine
   {
+    unsigned nstream;
+    
   public:
 
     //! Default Constructor

--- a/Signal/General/dsp/SingleThread.h
+++ b/Signal/General/dsp/SingleThread.h
@@ -214,6 +214,10 @@ namespace dsp {
     void set_cuda_device (std::string);
     unsigned get_cuda_ndevice () const { return cuda_device.size(); }
 
+    //! set the number of kernel streams per cuda device
+    void set_cuda_nstream (unsigned);
+    unsigned get_cuda_nstream () const { return nstream; }
+
     //! set the number of CPU threads to be used
     void set_nthread (unsigned);
 
@@ -257,6 +261,9 @@ namespace dsp {
 
     //! CUDA devices on which computations will take place
     std::vector<unsigned> cuda_device;
+
+    //! number of kernel streams per cuda device
+    unsigned nstream;
 
     //! application can make use of multiple cores
     bool can_thread;

--- a/Signal/General/dsp/SingleThread.h
+++ b/Signal/General/dsp/SingleThread.h
@@ -44,7 +44,7 @@ namespace dsp {
 
     //! Constructor
     SingleThread ();
-    
+
     //! Destructor
     ~SingleThread ();
 
@@ -87,6 +87,11 @@ namespace dsp {
     unsigned thread_id;
     void set_affinity (int core);
 
+    void set_input_stream (void* _input_stream) { input_stream = _input_stream; }
+
+    // Placeholder for CUDA event signaling a completed input memory transfer
+    void* input_event;
+
   protected:
 
     //! Any special operations that must be performed at the end of data
@@ -106,7 +111,7 @@ namespace dsp {
 	Prepared,    //! preparations completed
 	Run,         //! processing started
 	Done,        //! processing completed
-	Joined       //! completion acknowledged 
+	Joined       //! completion acknowledged
       };
 
     //! Processing state
@@ -135,6 +140,7 @@ namespace dsp {
 
     //! Create a new TimeSeries instance
     TimeSeries* new_time_series ();
+    TimeSeries* new_time_series (bool increase_buffers);
     TimeSeries* new_TimeSeries () { return new_time_series(); }
 
     //! The operations to be performed
@@ -151,6 +157,9 @@ namespace dsp {
 
     Reference::To<Memory> device_memory;
     void* gpu_stream;
+    
+    // Placeholder for CUDA stream in which input memory transfers occur
+    void* input_stream;
 
   };
 
@@ -170,7 +179,7 @@ namespace dsp {
 
     //! Prepare the input according to the configuration
     virtual void prepare (Input*);
-    
+
     //! external function used to prepare the input each time it is opened
     Functor< void(Input*) > input_prepare;
 
@@ -268,8 +277,3 @@ namespace dsp {
 }
 
 #endif // !defined(__SingleThread_h)
-
-
-
-
-

--- a/Signal/General/dsp/SingleThread.h
+++ b/Signal/General/dsp/SingleThread.h
@@ -233,6 +233,11 @@ namespace dsp {
     //! use input-buffering to compensate for operation edge effects
     bool input_buffering;
 
+    // keep input copies onto cuda device in their own stream so they
+    // don't overlap (allows them to be faster and encourages staggered
+    // kernel operations in other streams)
+    bool use_input_stream;
+
     //! use weighted time series to flag bad data
     bool weighted_time_series;
 

--- a/Signal/General/dsp/TransferCUDA.h
+++ b/Signal/General/dsp/TransferCUDA.h
@@ -23,6 +23,10 @@ namespace dsp {
     //! Default constructor - always out of place
     TransferCUDA(cudaStream_t _stream);
 
+    //! Constructor with input stream and completion event
+    TransferCUDA(cudaStream_t _stream, cudaStream_t _input_stream,
+                 cudaEvent_t _event);
+
     void set_kind (cudaMemcpyKind k) { kind = k; }
     void prepare ();
 
@@ -36,6 +40,10 @@ namespace dsp {
     cudaMemcpyKind kind;
 
     cudaStream_t stream;
+
+    cudaStream_t input_stream;
+
+    cudaEvent_t event;
 
   };
 

--- a/Signal/Pulsar/LoadToFold1.C
+++ b/Signal/Pulsar/LoadToFold1.C
@@ -353,6 +353,13 @@ void dsp::LoadToFold::construct () try
     // software filterbank constructor
     if (!filterbank)
       filterbank = config->filterbank.create();
+      
+#if HAVE_CUDA
+    // This allows multiple streams on GPU to share one copy of the dedispersion
+    // kernel.  NOTE: Like with the input stream, this should be updated to
+    // check for multiple devices and copy once for each.
+    filterbank->set_d_kernel_gpu_ptr(&(config->d_kernel_gpu));
+#endif
 
     if (!config->input_buffering)
       filterbank->set_buffering_policy (NULL);

--- a/Signal/Pulsar/LoadToFold1.C
+++ b/Signal/Pulsar/LoadToFold1.C
@@ -121,7 +121,8 @@ void dsp::LoadToFold::construct () try
   SingleThread::construct ();
 
   #if HAVE_CUDA
-  bool run_on_gpu = thread_id < config->get_cuda_ndevice();
+  bool run_on_gpu = thread_id < config->get_cuda_ndevice()
+                                * config->get_cuda_nstream();
   cudaStream_t stream = reinterpret_cast<cudaStream_t>( gpu_stream );
   #endif
 
@@ -1096,7 +1097,8 @@ catch (Error& error)
 void dsp::LoadToFold::configure_detection (Detection* detect, int noperations)
 {
 #if HAVE_CUDA
-  bool run_on_gpu = thread_id < config->get_cuda_ndevice();
+  bool run_on_gpu = thread_id < config->get_cuda_ndevice()
+                                * config->get_cuda_nstream();
   cudaStream_t stream = reinterpret_cast<cudaStream_t>( gpu_stream );
 
   if (run_on_gpu)

--- a/Signal/Pulsar/LoadToFold1.C
+++ b/Signal/Pulsar/LoadToFold1.C
@@ -107,12 +107,23 @@ unsigned count (const std::vector<T>& data, T element)
 
 void dsp::LoadToFold::construct () try
 {
+  #if HAVE_CUDA
+  // NOTE: probably want to set this on a device-by-device basis (since multiple
+  // gpu streams are presently set by setting the same device multiple times,
+  // this is written assuming all listed devices are the same)
+  if ( !config->input_stream )
+    cudaStreamCreate( reinterpret_cast<cudaStream_t*>(&config->input_stream) );
+  #endif
+
+  // Separate stream for input memcpy (gpu) allows better copy/execution
+  // parallelization.  This does nothing important if gpus are not being used.
+  SingleThread::set_input_stream(config->input_stream);
   SingleThread::construct ();
 
-#if HAVE_CUDA
+  #if HAVE_CUDA
   bool run_on_gpu = thread_id < config->get_cuda_ndevice();
   cudaStream_t stream = reinterpret_cast<cudaStream_t>( gpu_stream );
-#endif
+  #endif
 
   if (manager->get_info()->get_detected())
   {
@@ -159,7 +170,7 @@ void dsp::LoadToFold::construct () try
     if (config->times_minimum_nfft)
     {
       if (report_vitals)
-        cerr << "dspsr: setting filter length to minimum times " 
+        cerr << "dspsr: setting filter length to minimum times "
              << config->times_minimum_nfft << endl;
       kernel->set_times_minimum_nfft (config->times_minimum_nfft);
     }
@@ -218,20 +229,20 @@ void dsp::LoadToFold::construct () try
   if (!config->calibrator_database_filename.empty())
   {
     dsp::PolnCalibration* polcal = new PolnCalibration;
-   
+
     polcal-> set_database_filename (config->calibrator_database_filename);
 
     if (kernel)
     {
       if (!response_product)
         response_product = new ResponseProduct;
-    
+
       response_product->add_response (polcal);
       response_product->add_response (kernel);
-      
+
       response_product->set_copy_index (0);
       response_product->set_match_index (1);
-      
+
       response = response_product;
     }
   }
@@ -251,7 +262,7 @@ void dsp::LoadToFold::construct () try
     TimeSeries* skfilterbank_input = unpacked;
 
 #if HAVE_CUDA
-    if (run_on_gpu) 
+    if (run_on_gpu)
     {
       Unpacker* unpack_on_cpu = 0;
       unpack_on_cpu = manager->get_unpacker()->clone();
@@ -301,7 +312,7 @@ void dsp::LoadToFold::construct () try
     skdetector->set_thresholds (config->sk_m, config->sk_std_devs);
     if (config->sk_chan_start > 0 && config->sk_chan_end < config->filterbank.get_nchan())
       skdetector->set_channel_range (config->sk_chan_start, config->sk_chan_end);
-    skdetector->set_options (config->sk_no_fscr, config->sk_no_tscr, config->sk_no_ft); 
+    skdetector->set_options (config->sk_no_fscr, config->sk_no_tscr, config->sk_no_ft);
 
     skthread->append_operation (skdetector);
 
@@ -318,7 +329,7 @@ void dsp::LoadToFold::construct () try
     // we must return it to the required size for the SKFB
     if (!skresize)
       skresize = new Resize;
-    
+
     skresize->set_input(unpacked);
     skresize->set_output(unpacked);
     operations.push_back (skresize.get());
@@ -347,7 +358,7 @@ void dsp::LoadToFold::construct () try
 
     filterbank->set_input (unpacked);
     filterbank->set_output (convolved);
-    
+
     if (config->filterbank.get_convolve_when() == Filterbank::Config::During)
     {
       filterbank->set_response (response);
@@ -368,22 +379,22 @@ void dsp::LoadToFold::construct () try
   {
     if (!convolution)
       convolution = new Convolution;
-    
+
     convolution->set_response (response);
     if (!config->integration_turns)
       convolution->set_passband (passband);
-    
+
     if (filterbank_after_dedisp)
     {
-      convolution->set_input  (unpacked);  
+      convolution->set_input  (unpacked);
       convolution->set_output (unpacked);  // inplace
     }
     else
     {
-      convolution->set_input  (convolved);  
+      convolution->set_input  (convolved);
       convolution->set_output (convolved);  // inplace
     }
-    
+
     operations.push_back (convolution.get());
   }
 
@@ -405,10 +416,10 @@ void dsp::LoadToFold::construct () try
 
     if (!phased_filterbank)
     {
-      if (output_subints()) 
+      if (output_subints())
       {
 
-        Subint<PhaseLockedFilterbank> *sub_plfb = 
+        Subint<PhaseLockedFilterbank> *sub_plfb =
           new Subint<PhaseLockedFilterbank>;
 
         if (config->integration_length)
@@ -416,7 +427,7 @@ void dsp::LoadToFold::construct () try
           sub_plfb->set_subint_seconds (config->integration_length);
         }
 
-        else if (config->integration_turns) 
+        else if (config->integration_turns)
         {
           sub_plfb->set_subint_turns (config->integration_turns);
           sub_plfb->set_fractional_pulses (config->fractional_pulses);
@@ -465,7 +476,7 @@ void dsp::LoadToFold::construct () try
 
     return;
     // the phase-locked filterbank does its own detection and folding
-    
+
   }
 
   Reference::To<Fold> presk_fold;
@@ -473,7 +484,7 @@ void dsp::LoadToFold::construct () try
 
   // peform zapping based on the results of the SKFilterbank
   if (config->sk_zap)
-  { 
+  {
     if (config->nosk_too)
     {
       Detection* presk_detect = new Detection;
@@ -584,7 +595,7 @@ void dsp::LoadToFold::construct () try
   {
     if (Operation::verbose)
       cerr << "LoadToFold::construct fourth order moments" << endl;
-              
+
     FourthMoment* fourth = new FourthMoment;
     operations.push_back (fourth);
 
@@ -732,10 +743,10 @@ void dsp::LoadToFold::prepare ()
   {
     if ( config->excision_nsample )
       excision -> set_ndat_per_weight ( config->excision_nsample );
-  
+
     if ( config->excision_threshold > 0 )
       excision -> set_threshold ( config->excision_threshold );
-    
+
     if ( config->excision_cutoff >= 0 )
       excision -> set_cutoff_sigma ( config->excision_cutoff );
   }
@@ -811,10 +822,10 @@ void dsp::LoadToFold::prepare ()
 
   if (convolution)
   {
-    minimum_samples = convolution->get_minimum_samples () * 
+    minimum_samples = convolution->get_minimum_samples () *
       convolution->get_input()->get_nchan();
     if (report_vitals)
-      cerr << "dspsr: convolution requires at least " 
+      cerr << "dspsr: convolution requires at least "
            << minimum_samples << " samples" << endl;
 
     if (!config->input_buffering)
@@ -857,7 +868,7 @@ void dsp::LoadToFold::prepare ()
     skresize->set_resize_samples (skfb_increment);
 
     if (Operation::verbose)
-      cerr << "dsp::LoadToFold::prepare block_size will be adjusted by " 
+      cerr << "dsp::LoadToFold::prepare block_size will be adjusted by "
           << skfb_increment << " samples for SKFB" << endl;
   }
 
@@ -958,7 +969,7 @@ void dsp::LoadToFold::build_fold (TimeSeries* to_fold)
   }
 }
 
-dsp::PhaseSeriesUnloader* 
+dsp::PhaseSeriesUnloader*
 dsp::LoadToFold::get_unloader (unsigned ifold)
 {
   if (ifold == unloader.size())
@@ -990,7 +1001,7 @@ void dsp::LoadToFold::build_fold (Reference::To<Fold>& fold,
     {
       if (Operation::verbose)
 	cerr << "dsp::LoadToFold::build_fold prepare CyclicFold" << endl;
-      
+
       CyclicFold* cs = new CyclicFold;
       cs -> set_mover (config->cyclic_mover);
       cs -> set_nchan (config->cyclic_nchan);
@@ -1006,7 +1017,7 @@ void dsp::LoadToFold::build_fold (Reference::To<Fold>& fold,
       fold = new Fold;
     }
   }
-  else if (config->cyclic_nchan) 
+  else if (config->cyclic_nchan)
   {
     if (Operation::verbose)
       cerr << "dsp::LoadToFold::build_fold prepare Subint<CyclicFold>" << endl;
@@ -1020,29 +1031,29 @@ void dsp::LoadToFold::build_fold (Reference::To<Fold>& fold,
     if (config->integration_length)
     {
       subfold -> set_subint_seconds (config->integration_length);
-	
+
       if (config->minimum_integration_length > 0)
 	unloader->set_minimum_integration_length (config->minimum_integration_length);
     }
     else
-      throw Error (InvalidState, "dsp::LoadToFold::build_fold", 
+      throw Error (InvalidState, "dsp::LoadToFold::build_fold",
 		   "Single-pulse cyclic spectra not supported");
-    
+
     subfold -> set_unloader (unloader);
 
     fold = subfold;
   }
-  else 
+  else
   {
     if (Operation::verbose)
       cerr << "dsp::LoadToFold::build_fold prepare Subint<Fold>" << endl;
 
     Subint<Fold>* subfold = new Subint<Fold>;
-    
+
     if (config->integration_length)
     {
       subfold -> set_subint_seconds (config->integration_length);
-	
+
       if (config->minimum_integration_length > 0)
 	unloader->set_minimum_integration_length (config->minimum_integration_length);
     }
@@ -1095,7 +1106,7 @@ void dsp::LoadToFold::configure_detection (Detection* detect, int noperations)
   }
 #endif
 
-  if (manager->get_info()->get_npol() == 1) 
+  if (manager->get_info()->get_npol() == 1)
   {
     cerr << "Only single polarization detection available" << endl;
     detect->set_output_state( Signal::PP_State );
@@ -1141,7 +1152,7 @@ void dsp::LoadToFold::configure_detection (Detection* detect, int noperations)
 void dsp::LoadToFold::configure_fold (unsigned ifold, TimeSeries* to_fold)
 {
   Reference::To<ObservationChange> change;
-  
+
   if (ifold && ifold <= config->additional_pulsars.size())
   {
     change = new ObservationChange;
@@ -1152,21 +1163,21 @@ void dsp::LoadToFold::configure_fold (unsigned ifold, TimeSeries* to_fold)
   {
     if (!change)
       change = new ObservationChange;
-    
+
     Pulsar::Parameters* ephem = config->ephemerides[ifold];
     change->set_source( ephem->get_name() );
     change->set_dispersion_measure( get_dispersion_measure(ephem) );
-    
+
     fold[ifold]->set_pulsar_ephemeris ( config->ephemerides[ifold] );
   }
 
   if (ifold < config->predictors.size())
   {
     fold[ifold]->set_folding_predictor ( config->predictors[ifold] );
-    
+
     Pulsar::SimplePredictor* simple
       = dynamic_kast<Pulsar::SimplePredictor>( config->predictors[ifold] );
-    
+
     if (simple)
     {
       config->dispersion_measure = simple->get_dispersion_measure();
@@ -1183,38 +1194,38 @@ void dsp::LoadToFold::configure_fold (unsigned ifold, TimeSeries* to_fold)
 
       if (!change)
 	change = new ObservationChange;
-      
+
       change->set_source( simple->get_name() );
       change->set_dispersion_measure( simple->get_dispersion_measure() );
     }
-  }    
-  
+  }
+
   fold[ifold]->set_input (to_fold);
-  
+
   if (change)
     fold[ifold]->set_change (change);
-  
+
   if (ifold && ifold <= config->additional_pulsars.size())
   {
     if (!change)
       change = new ObservationChange;
-    
+
     /*
       If additional pulsar names have been specified, then Fold::prepare
-      will have retrieved an ephemeris, and the DM from this ephemeris 
+      will have retrieved an ephemeris, and the DM from this ephemeris
       should make its way into the folded profile.
     */
     const Pulsar::Parameters* ephem = fold[ifold]->get_pulsar_ephemeris ();
     change->set_dispersion_measure( get_dispersion_measure(ephem) );
   }
-  
+
   // fold[ifold]->reset();
-    
+
   if (config->asynchronous_fold)
     asynch_fold[ifold] = new OperationThread( fold[ifold].get() );
   else
     operations.push_back( fold[ifold].get() );
-  
+
 #if HAVE_CUDA
   if (gpu_stream != undefined_stream)
   {
@@ -1243,10 +1254,10 @@ void dsp::LoadToFold::prepare_archiver( Archiver* archiver )
 
   if (output_subints() && config->subints_per_archive)
   {
-    cerr << "dspsr: Archives with " << 
+    cerr << "dspsr: Archives with " <<
         config->subints_per_archive << " sub-integrations" << endl;
     archiver->set_use_single_archive (true);
-    archiver->set_subints_per_file (config->subints_per_archive); 
+    archiver->set_subints_per_file (config->subints_per_archive);
   }
 
   if (config->integration_turns || config->no_dynamic_extensions)
@@ -1264,7 +1275,7 @@ void dsp::LoadToFold::prepare_archiver( Archiver* archiver )
       archiver->set_convention( epoch_convention = new FilenameEpoch );
 
     // If archive_filename was specified, figure out whether
-    // it represents a date string or not by looking for '%' 
+    // it represents a date string or not by looking for '%'
     // characters.
     else if (!config->archive_filename.empty())
     {
@@ -1279,7 +1290,7 @@ void dsp::LoadToFold::prepare_archiver( Archiver* archiver )
       archiver->set_convention( epoch_convention = new FilenameEpoch );
   }
 
-  if (epoch_convention && output_subints() 
+  if (epoch_convention && output_subints()
       && (config->single_archive || config->subints_per_archive))
     epoch_convention->report_unload = false;
 
@@ -1315,13 +1326,13 @@ void dsp::LoadToFold::prepare_archiver( Archiver* archiver )
 
   if (sample_delay)
     archiver->set_archive_dedispersed (true);
-  
+
   if (config->jobs.size())
     archiver->set_script (config->jobs);
-  
+
   if (fold.size() > 1)
     archiver->set_path_add_source (true);
-  
+
   if (!config->archive_extension.empty())
     archiver->set_extension (config->archive_extension);
 
@@ -1382,7 +1393,7 @@ void dsp::LoadToFold::run ()
   if (log)
     for (unsigned iul=0; iul < unloader.size(); iul++)
       unloader[iul]->set_cerr (*log);
-  
+
   SingleThread::run ();
 }
 
@@ -1430,4 +1441,3 @@ catch (Error& error)
 {
   throw error += "dsp::LoadToFold::finish";
 }
-

--- a/Signal/Pulsar/LoadToFoldConfig.C
+++ b/Signal/Pulsar/LoadToFoldConfig.C
@@ -14,6 +14,9 @@ dsp::LoadToFold::Config::Config ()
   can_cuda = true;
   can_thread = true;
 
+  // useful for gpu filterbank
+  input_stream = (void*) 0;
+
   minimum_RAM = 0;
   maximum_RAM = 256 * 1024 * 1024;
   times_minimum_ndat = 1;

--- a/Signal/Pulsar/dsp/LoadToFoldConfig.h
+++ b/Signal/Pulsar/dsp/LoadToFoldConfig.h
@@ -43,6 +43,9 @@ namespace dsp {
     //! Default constructor
     Config ();
 
+    // useful for gpu filterbank
+    void* input_stream;
+
     // set block size to this factor times the minimum possible
     void set_times_minimum_ndat (unsigned);
     unsigned get_times_minimum_ndat () const { return times_minimum_ndat; }

--- a/Signal/Pulsar/dsp/LoadToFoldConfig.h
+++ b/Signal/Pulsar/dsp/LoadToFoldConfig.h
@@ -45,6 +45,7 @@ namespace dsp {
 
     // useful for gpu filterbank
     void* input_stream;
+    void* d_kernel_gpu;
 
     // set block size to this factor times the minimum possible
     void set_times_minimum_ndat (unsigned);


### PR DESCRIPTION
In the case where input nchan was the same as number of output filterbank channels, would get an ichan >= nchan error when calculating the output span.  This is fixed, though it has made another problem apparent.  FourBitUnpacker requires ndat to be even (assuming, I suppose, that each byte is populated by two data points) but this is not necessarily the case.  I haven't done anything about this, but I did notice that in the recent change to BitUnpacker, 'blockbytes' was being calculated incorrectly, so I changed that too.
