### PR TITLE
Frequency bundling introduced

### DIFF
--- a/Kernel/Classes/ASCIIObservation.C
+++ b/Kernel/Classes/ASCIIObservation.C
@@ -33,7 +33,7 @@ dsp::ASCIIObservation::ASCIIObservation (const char* header)
   required_keys.push_back("NPOL");
   required_keys.push_back("NBIT");
   // NDIM and NCHAN have a default value of 1
-  required_keys.push_back("TSAMP");
+  // TSAMP has a default value of NCHAN/BW  
   required_keys.push_back("UTC_START");
   required_keys.push_back("OBS_OFFSET");
 
@@ -298,8 +298,24 @@ void dsp::ASCIIObservation::load (const char* header)
   // TSAMP
   //
   double sampling_interval=0.0;
-  ascii_header_check (header, "TSAMP", "%lf", &sampling_interval);
-
+  if (ascii_header_check (header, "TSAMP", "%lf", &sampling_interval) < 0)
+  {
+    if (bw > 0)
+    {
+      sampling_interval = scan_nchan / bw;
+      if (verbose)
+        cerr << "dsp::ASCIIObservation::load Setting TSAMP to "
+             << "NCHAN/BW=" << sampling_interval << " us" << endl;
+    }
+    else
+    {
+      sampling_interval = 1.0;
+      if (verbose)
+        cerr << "dsp::ASCIIObservation::load No TSAMP or BW provided, "
+             << "setting TSAMP to 1 us" << endl;
+    }
+  }
+    
   /* IMPORTANT: TSAMP is the sampling period in microseconds */
   sampling_interval *= 1e-6;
 

--- a/Kernel/Classes/BitUnpacker.C
+++ b/Kernel/Classes/BitUnpacker.C
@@ -47,33 +47,47 @@ const dsp::BitTable* dsp::BitUnpacker::get_table () const
 
 void dsp::BitUnpacker::unpack ()
 {
-  const uint64_t   ndat  = input->get_ndat();
+  const uint64_t ndat  = input->get_ndat();
 
   const unsigned nchan = input->get_nchan();
   const unsigned npol  = input->get_npol();
   const unsigned ndim  = input->get_ndim();
+  const unsigned nbit  = input->get_nbit();
 
   const unsigned nskip = npol * nchan * ndim;
   const unsigned fskip = ndim;
 
-  unsigned offset = 0;
+  // Step through the array in small block sizes so that the matrix
+  // transpose (for nchan>1 case) remains cache-friendly.
+  const unsigned blockdat = npol*nchan*ndim > 32 ? npol*nchan*ndim : 32;
+  const unsigned blockbytes = blockdat*npol*nchan*ndim*nbit/8;
 
-  for (unsigned ichan=0; ichan<nchan; ichan++)
+  const unsigned char* iptr = input->get_rawptr();
+
+  for (uint64_t idat=0; idat<ndat; idat+=blockdat, iptr+=blockbytes)
   {
-    for (unsigned ipol=0; ipol<npol; ipol++)
+    unsigned offset = 0;
+    const unsigned ndatblock = (blockdat>(ndat-idat)) ? ndat-idat : blockdat;
+    for (unsigned ichan=0; ichan<nchan; ichan++)
     {
-      for (unsigned idim=0; idim<ndim; idim++)
+      for (unsigned ipol=0; ipol<npol; ipol++)
       {
-	const unsigned char* from = input->get_rawptr() + offset;
-	float* into = output->get_datptr (ichan, ipol) + idim;
-	unsigned long* hist = get_histogram (offset);
- 
+        for (unsigned idim=0; idim<ndim; idim++)
+        {
+          //offset = idim + ipol*ndim + ichan*npol*ndim;
+          //const unsigned char* from = input->get_rawptr() + offset;
+          const unsigned char* from = iptr + offset;
+          float* into = output->get_datptr (ichan, ipol) + ndim*idat + idim;
+          unsigned long* hist = get_histogram (offset);
+   
 #ifdef _DEBUG
-        cerr << "c=" << ichan << " p=" << ipol << " d=" << idim << endl;
+          cerr << "c=" << ichan << " p=" << ipol << " d=" << idim << endl;
 #endif
  
-	unpack (ndat, from, nskip, into, fskip, hist);
-	offset ++;
+          unpack (ndatblock, from, nskip, into, fskip, hist);
+          //unpack (ndat, from, nskip, into, fskip, hist);
+          offset ++;
+        }
       }
     }
   }

--- a/Kernel/Classes/BitUnpacker.C
+++ b/Kernel/Classes/BitUnpacker.C
@@ -60,7 +60,7 @@ void dsp::BitUnpacker::unpack ()
   // Step through the array in small block sizes so that the matrix
   // transpose (for nchan>1 case) remains cache-friendly.
   const unsigned blockdat = npol*nchan*ndim > 32 ? npol*nchan*ndim : 32;
-  const unsigned blockbytes = blockdat*npol*nchan*ndim*nbit/8;
+  const unsigned blockbytes = blockdat*nbit/8;
 
   const unsigned char* iptr = input->get_rawptr();
 

--- a/Kernel/Classes/DataSeries.C
+++ b/Kernel/Classes/DataSeries.C
@@ -33,6 +33,7 @@ void dsp::DataSeries::initi()
   buffer = NULL;
   size = 0;
   subsize = 0;
+  nbundle = 1;
   set_nbit( 8 * sizeof(float) );
 }
   
@@ -129,10 +130,10 @@ void dsp::DataSeries::resize (uint64_t nsamples, unsigned char*& old_buffer)
   if (verbose)
     cerr << "dsp::DataSeries::resize"
             " npol=" << get_npol() << 
-            " nchan=" << get_nchan() << endl;
+            " nchan=" << get_nchan()/nbundle << endl;
 
   // Number of bytes needed to be allocated
-  uint64_t require = (nbits_required*get_npol()*get_nchan())/8;
+  uint64_t require = (nbits_required*get_npol()*get_nchan()/nbundle)/8;
 
   if (verbose)
     cerr << "dsp::DataSeries::resize nbytes=nbits/8*npol*nchan=" << require 
@@ -203,10 +204,10 @@ void dsp::DataSeries::reshape ()
 {
   subsize = (get_ndim() * get_ndat() * get_nbit()) / 8;
   
-  if (subsize*get_npol()*get_nchan() > size)
+  if (subsize*get_npol()*get_nchan()/nbundle > size)
     throw Error (InvalidState, "dsp::DataSeries::reshape",
 		 "subsize="UI64" * npol=%d * nchan=%d > size="UI64,
-		 subsize, get_npol(), get_nchan(), size);
+		 subsize, get_npol(), get_nchan()/nbundle, size);
 
   if (verbose)
     cerr << "dsp::DataSeries::reshape size=" << size << " bytes"
@@ -228,6 +229,11 @@ void dsp::DataSeries::reshape (unsigned new_npol, unsigned new_ndim)
 
   set_npol (new_npol);
   set_ndim (new_ndim);
+}
+
+void dsp::DataSeries::set_total_nbundle (unsigned _nbundle)
+{
+  nbundle = _nbundle;
 }
 
 //! Returns a uchar pointer to the first piece of data
@@ -286,7 +292,7 @@ dsp::DataSeries& dsp::DataSeries::operator = (const DataSeries& copy)
 
   uint64_t npt = (get_ndat() * get_ndim() * get_nbit())/8;
 
-  for (unsigned ichan=0; ichan<get_nchan(); ichan++){
+  for (unsigned ichan=0; ichan<(get_nchan()/nbundle); ichan++){
     for (unsigned ipol=0; ipol<get_npol(); ipol++) {
       unsigned char* dest = get_udatptr (ichan, ipol);
       const unsigned char* src = copy.get_udatptr (ichan, ipol);
@@ -306,10 +312,10 @@ dsp::DataSeries& dsp::DataSeries::swap_data(dsp::DataSeries& ts)
   uint64_t tmp2 = size; size = ts.size; ts.size = tmp2;
   uint64_t tmp3 = subsize; subsize = ts.subsize; ts.subsize = tmp3;
 
-  if( subsize*get_npol()*get_nchan() > size )
+  if( subsize*get_npol()*get_nchan()/nbundle > size )
     throw Error(InvalidState,"dsp::DataSeries::swap_data()",
 		"BUG! subsize*get_npol()*get_nchan() > size ("UI64" * %d * %d > "UI64")\n",
-		subsize,get_npol(),get_nchan(),size);
+		subsize,get_npol(),get_nchan()/nbundle,size);
 
   return *this;
 }
@@ -318,6 +324,14 @@ dsp::DataSeries& dsp::DataSeries::swap_data(dsp::DataSeries& ts)
 void dsp::DataSeries::internal_match (const DataSeries* other)
 {
   uint64_t required = other->size;
+  unsigned other_nbundle = other->get_total_nbundle();
+  // Handle case where everything is the same except nbundle
+  if (other_nbundle > nbundle)
+    required *= other_nbundle/nbundle;
+  else
+    required /= nbundle/other_nbundle;
+    
+  //cerr << "ERIK: internal_match: required = " << required << endl;
 
   if (size < required)
   {

--- a/Kernel/Classes/DummyFile.C
+++ b/Kernel/Classes/DummyFile.C
@@ -56,6 +56,12 @@ void dsp::DummyFile::open_file (const char* filename)
   
   // Read obs info from ASCII file
   info = new ASCIIObservation(header);
+  
+  // cannot load less than a byte. set the time sample resolution accordingly
+  unsigned bits_per_byte = 8;
+  resolution = bits_per_byte / get_info()->get_nbit();
+  if (resolution == 0)
+    resolution = 1;
 }
 
 void dsp::DummyFile::close ()

--- a/Kernel/Classes/IOManager.C
+++ b/Kernel/Classes/IOManager.C
@@ -356,13 +356,16 @@ uint64_t dsp::IOManager::set_block_size (uint64_t minimum_samples)
   unsigned nchan = info->get_nchan();
 
   // each nbit number will be unpacked into a float
-  double nbyte = double(nbit)/8 + copies * sizeof(float);
+  double nbyte_packed = double(nbit)/8;
+  double nbyte_unpacked = copies * sizeof(float);
 
   if (verbose)
     cerr << "dsp::IOManager::set_block_size copies=" << copies
-         << " nbit=" << nbit << " nbyte=" << nbyte << endl;
+         << " nbit=" << nbit << " nbyte_packed=" << nbyte_packed
+         << " nbyte_unpacked=" << nbyte_unpacked 
+         << " nbyte_unpacked/nbundle=" << nbyte_unpacked/nbundle << endl;
 
-  double nbyte_dat = nbyte * ndim * npol * nchan;
+  double nbyte_dat = (nbyte_packed+nbyte_unpacked)*nchan*ndim*npol;
 
   uint64_t block_size = multiple_greater (minimum_samples, resolution);
 

--- a/Kernel/Classes/Operation.C
+++ b/Kernel/Classes/Operation.C
@@ -40,6 +40,9 @@ dsp::Operation::Operation (const Operation& op)
 
   discarded_weights = op.discarded_weights;
   total_weights = op.total_weights;
+  
+  input_bundle = 0;
+  nbundle = 1;
 }
 
 //! All sub-classes must specify name and capacity for inplace operation
@@ -60,6 +63,9 @@ dsp::Operation::Operation (const char* _name)
   set_scratch_called = false;
 
   prepared = false;
+  
+  input_bundle = 0;
+  nbundle = 1;
 }
 
 
@@ -143,6 +149,12 @@ void dsp::Operation::set_scratch (Scratch* s)
 bool dsp::Operation::scratch_was_set () const
 {
   return set_scratch_called;
+}
+
+void dsp::Operation::set_input_bundle (unsigned _input_bundle, unsigned _nbundle)
+{
+  input_bundle = _input_bundle;
+  nbundle = _nbundle;
 }
 
 //! Combine accumulated results with another operation

--- a/Kernel/Classes/TimeSeries.C
+++ b/Kernel/Classes/TimeSeries.C
@@ -44,6 +44,8 @@ void dsp::TimeSeries::init ()
   reserve_ndat = 0;
   reserve_nfloat = 0;
   input_sample = -1;
+  input_bundle = 0;
+  nbundle = 1;
   zeroed_data = false;
 }
 
@@ -95,12 +97,12 @@ dsp::TimeSeries::use_data(float* _buffer, uint64_t _ndat)
 {
   if( get_nchan() != 1 || get_npol() != 1 )
     throw Error(InvalidState,"dsp::TimeSeries::use_data()",
-		"This function is only for nchan=1 npol=1 TimeSeries --- you had %d %d",
-		get_nchan(), get_npol());
+    "This function is only for nchan=1 npol=1 TimeSeries --- you had %d %d",
+    get_nchan(), get_npol());
 
   if( !_buffer )
     throw Error(InvalidState,"dsp::TimeSeries::use_data()",
-		"Input data was null!");
+                "Input data was null!");
 
   resize( 0 );
   buffer = (unsigned char*)_buffer;
@@ -256,7 +258,14 @@ float* dsp::TimeSeries::get_datptr (unsigned ichan, unsigned ipol)
     throw Error (InvalidState, "dsp::TimeSeries::get_datptr",
 		 "Not in Frequency, Polarization, Time Order");
 
-  return reinterpret_cast<float*>( get_udatptr(ichan,ipol) );
+  if (ichan < get_ichan_start() || ichan >= get_ichan_start()+get_nchan_bundle())
+    throw Error (InvalidState, "dsp::TimeSeries::get_datptr",
+     "ichan %d not in bundle range %d to %d",
+     ichan, get_ichan_start(), get_ichan_start()+get_nchan_bundle()-1);
+
+  // Offset ichan to account for channel bundling
+  unsigned offset_ichan = ichan - get_ichan_start();
+  return reinterpret_cast<float*>( get_udatptr(offset_ichan,ipol) );
 }
 
 //! Return pointer to the specified data block
@@ -267,7 +276,14 @@ dsp::TimeSeries::get_datptr (unsigned ichan, unsigned ipol) const
     throw Error (InvalidState, "dsp::TimeSeries::get_datptr",
 		 "Not in Frequency, Polarization, Time Order");
 
-  return reinterpret_cast<const float*>( get_udatptr(ichan,ipol) );
+  if (ichan < get_ichan_start() || ichan >= get_ichan_start()+get_nchan_bundle())
+    throw Error (InvalidState, "dsp::TimeSeries::get_datptr",
+     "ichan %d not in bundle range %d to %d",
+    ichan, get_ichan_start(), get_ichan_start()+get_nchan_bundle()-1);
+
+  // Offset ichan to account for channel bundling
+  unsigned offset_ichan = ichan - get_ichan_start();
+  return reinterpret_cast<const float*>( get_udatptr(offset_ichan,ipol) );
 }
 
 //! Return pointer to the specified data block
@@ -295,6 +311,16 @@ uint64_t dsp::TimeSeries::get_nfloat_span () const
   return internal_get_subsize() / sizeof(float);
 }
 
+unsigned dsp::TimeSeries::get_ichan_start() const
+{
+  return input_bundle * get_nchan_bundle();
+}
+
+unsigned dsp::TimeSeries::get_nchan_bundle () const
+{
+  return get_nchan() / nbundle;
+}
+
 double dsp::TimeSeries::mean (unsigned ichan, unsigned ipol)
 {
   if (get_ndim() != 1)
@@ -320,6 +346,8 @@ void dsp::TimeSeries::internal_match (const TimeSeries* other)
   reserve_ndat = other->reserve_ndat;
   reserve_nfloat = other->reserve_nfloat;
   input_sample = other->input_sample;
+  if (other->nbundle == nbundle)
+    input_bundle = other->input_bundle;
 
   uint64_t offset = other->data - (float*)other->buffer;
 
@@ -364,8 +392,8 @@ dsp::TimeSeries& dsp::TimeSeries::operator += (const TimeSeries& add)
 
     return *this;
   }
-
-  for (unsigned ichan=0; ichan<get_nchan(); ichan++)
+  
+  for (unsigned ichan=get_ichan_start(); ichan<(get_ichan_start()+get_nchan_bundle()); ichan++)
   {
     for (unsigned ipol=0; ipol<get_npol(); ipol++)
     {
@@ -386,8 +414,8 @@ dsp::TimeSeries& dsp::TimeSeries::operator *= (float mult){
 
   if( fabs(mult-1.0) < 1.0e-9 )
     return *this;
-
-  for (unsigned ichan=0; ichan<get_nchan(); ichan++){
+    
+  for (unsigned ichan=get_ichan_start(); ichan<(get_ichan_start()+get_nchan_bundle()); ichan++){
     for (unsigned ipol=0; ipol<get_npol(); ipol++) {
       float* dat = get_datptr(ichan,ipol);
       unsigned npts = unsigned(get_ndat()*get_ndim());
@@ -410,6 +438,12 @@ void dsp::TimeSeries::prepend_checks (const dsp::TimeSeries* pre,
                  "data to be prepended end sample="I64"; "
                  "not contiguous with start sample="I64,
                  pre->input_sample + pre_ndat, input_sample);
+                 
+  if (pre->input_bundle != uint64_t(input_bundle))
+    throw Error (InvalidState, "dsp::TimeSeries::prepend_checks",
+                 "data to be prepended input bundle="I64"; "
+                 "not the same as input bundle="I64,
+                 pre->input_bundle, input_bundle);
 }
 
 void dsp::TimeSeries::prepend (const dsp::TimeSeries* pre, uint64_t pre_ndat)
@@ -459,7 +493,7 @@ void dsp::TimeSeries::copy_data (const dsp::TimeSeries* copy,
     switch (order)
     {
     case OrderFPT:
-      for (unsigned ichan=0; ichan<get_nchan(); ichan++)
+      for (unsigned ichan=get_ichan_start(); ichan<(get_ichan_start()+get_nchan_bundle()); ichan++)
       {
         for (unsigned ipol=0; ipol<get_npol(); ipol++)
         {
@@ -485,6 +519,8 @@ void dsp::TimeSeries::copy_data (const dsp::TimeSeries* copy,
   }
 
   input_sample = copy->input_sample + idat_start;
+  input_bundle = copy->input_bundle;
+  nbundle = copy->nbundle;
 }
 catch (Error& error)
 {
@@ -578,8 +614,8 @@ void dsp::TimeSeries::check (float min, float max)
   max *= scale;
 
   uint64_t _ndat = get_ndat();
-
-  for (unsigned ichan=0; ichan<get_nchan(); ichan++)
+  
+  for (unsigned ichan=get_ichan_start(); ichan<(get_ichan_start()+get_nchan_bundle()); ichan++)
     for (unsigned ipol=0; ipol<get_npol(); ipol++) {
 
       float* dat = get_datptr (ichan, ipol);
@@ -686,27 +722,29 @@ void dsp::TimeSeries::finite_check () const
   unsigned non_finite = 0;
 
   if (verbose)
-    cerr << "dsp::TimeSeries::finite_check nchan=" << nchan << " npol=" << npol
-	 << " ndim=" << get_ndim() << " ndat=" << get_ndat() << endl;
-
-  for (unsigned ichan=0; ichan < nchan; ichan++)
+    cerr << "dsp::TimeSeries::finite_check nchan=" << nchan <<
+            " nchan_bundle=" << get_nchan_bundle() <<
+            " ichan_start=" << get_ichan_start() << " npol=" << npol <<
+            " ndim=" << get_ndim() << " ndat=" << get_ndat() << endl;
+   
+  for (unsigned ichan=get_ichan_start(); ichan<(get_ichan_start()+get_nchan_bundle()); ichan++)
     for (unsigned ipol=0; ipol < npol; ipol++)
     {
       const float* from = get_datptr (ichan, ipol);
       for (unsigned ibin=0; ibin < nfloat; ibin++)
-	if (!finite(from[ibin]))
-	{
+        if (!finite(from[ibin]))
+        {
 #ifdef _DEBUG
-	  cerr << "not finite ichan=" << ichan << " ipol=" << ipol
-	       << " ptr=" << from << " ibin=" << ibin << endl;
+          cerr << "not finite ichan=" << ichan << " ipol=" << ipol
+               << " ptr=" << from << " ibin=" << ibin << endl;
 #endif
-	  non_finite ++;
-	}
+          non_finite ++;
+        }
     }
 
   if (non_finite)
     throw Error (InvalidParam, "dsp::TimeSeries::finite_check",
-		 "%u/%u non-finite values",
-		 non_finite, nfloat * nchan * npol);
+                 "%u/%u non-finite values",
+                 non_finite, nfloat * get_nchan_bundle() * npol);
 }
 

--- a/Kernel/Classes/dsp/DataSeries.h
+++ b/Kernel/Classes/dsp/DataSeries.h
@@ -96,6 +96,12 @@ namespace dsp {
     //! Stride (in bytes) between the same time sample in different chan/pol
     virtual uint64_t get_subsize(){ return subsize; }
 
+    //! Get the total number of bundles being used
+    unsigned get_total_nbundle () const { return nbundle; }
+    
+    //! Set the total number of bundles being used
+    void set_total_nbundle (unsigned _nbundle); // { nbundle = _nbundle; }
+
     //! Match the internal memory layout of another DataSeries
     virtual void internal_match (const DataSeries*);
 
@@ -128,6 +134,9 @@ namespace dsp {
 
     //! The number of BYTES in a data sub-division
     uint64_t subsize;
+    
+    //! The number of bundles input channels have been divided into
+    unsigned nbundle;
 
     //! The memory manager
     Reference::To<Memory> memory;

--- a/Kernel/Classes/dsp/Operation.h
+++ b/Kernel/Classes/dsp/Operation.h
@@ -119,6 +119,10 @@ namespace dsp {
     //! Set the scratch space
     virtual void set_scratch (Scratch*);
     bool scratch_was_set () const;
+    
+    //! Set the bundle of frequency channels currently being operated on
+    // along with the total number of bundles
+    void set_input_bundle (unsigned _input_bundle, unsigned _nbundle);
 
   protected:
 
@@ -155,6 +159,9 @@ namespace dsp {
 
     //! Set true when preparation optimizations are completed
     bool prepared;
+
+    //! The input bundle and total number of bundles
+    unsigned input_bundle, nbundle;
 
   };
   

--- a/Kernel/Classes/dsp/TimeSeries.h
+++ b/Kernel/Classes/dsp/TimeSeries.h
@@ -127,6 +127,18 @@ namespace dsp {
     //! Used to arrange pieces in order during input buffering
     void set_input_sample (uint64_t sample) { input_sample = sample; }
 
+    //! Return the channel bundle number
+    unsigned get_input_bundle () const { return input_bundle; }
+    
+    //! Set the channel bundle number
+    void set_input_bundle (unsigned bundle) { input_bundle = bundle; }
+
+    //! Convenience function to calculate the number of channels per bundle
+    unsigned get_nchan_bundle() const;
+    
+    //! Convenience function to calculate the lowest ichan in this bundle
+    unsigned get_ichan_start() const;
+
     //! Get the span (number of floats)
     uint64_t get_nfloat_span () const;
 
@@ -196,6 +208,15 @@ namespace dsp {
     //! Sample offset from start of source
     /*! Set by Unpacker class and used by multithreaded InputBuffering */
     int64_t input_sample;
+    
+    // Bundles are groups of input channels processed together, which can be
+    // useful as an alternative to loading all channels when nchan >> 1.
+    // This variable keeps track of which bundle is being worked on.
+    unsigned input_bundle;
+    
+    // The total number of bundles being used, of which this TimeSeries
+    // represents one
+    //unsigned nbundle; <-- MOVED TO DATASERIES
 
     //! Called by constructor to initialise variables
     void init ();

--- a/Signal/General/Convolution.C
+++ b/Signal/General/Convolution.C
@@ -207,6 +207,8 @@ void dsp::Convolution::prepare_output ()
 
   // prepare the output TimeSeries
   output->copy_configuration (input);
+  output->set_total_nbundle(input->get_total_nbundle());
+  output->set_input_bundle(input->get_input_bundle());
 
   output->set_state( Signal::Analytic );
   output->set_ndim( 2 );

--- a/Signal/General/Detection.C
+++ b/Signal/General/Detection.C
@@ -226,16 +226,18 @@ void dsp::Detection::square_law ()
                  "square law detection not yet implemented for the GPU");
 
   const unsigned nchan = input->get_nchan();
+  const unsigned ichan_start = input->get_ichan_start();
+  const unsigned nchan_bundle = input->get_nchan_bundle();
   const unsigned npol = input->get_npol();
   
   bool order_fpt = input->get_order() == TimeSeries::OrderFPT;
 
-  const unsigned loop_nchan = (order_fpt) ? nchan : 1;
+  const unsigned loop_nchan = (order_fpt) ? nchan_bundle : 1;
   const unsigned loop_npol = (order_fpt) ? npol : 1;
   const unsigned factor = (order_fpt) ? 1 : (nchan * npol);
   const uint64_t nfloat = input->get_ndim() * input->get_ndat() * factor;
 
-  for (unsigned ichan=0; ichan<loop_nchan; ichan++)
+  for (unsigned ichan=ichan_start; ichan<(ichan_start+loop_nchan); ichan++)
   {
     for (unsigned ipol=0; ipol<loop_npol; ipol++)
     {
@@ -244,15 +246,15 @@ void dsp::Detection::square_law ()
       register const float* dend = NULL;
       
       if (order_fpt)
-	{
-	  out_ptr = output->get_datptr (ichan,ipol);
-	  in_ptr = input->get_datptr (ichan,ipol);
-	}
+	    {
+	      out_ptr = output->get_datptr (ichan,ipol);
+	      in_ptr = input->get_datptr (ichan,ipol);
+	    }
       else
-	{
-	  out_ptr = output->get_dattfp ();
-	  in_ptr = input->get_dattfp ();
-	}
+	    {
+	      out_ptr = output->get_dattfp ();
+	      in_ptr = input->get_dattfp ();
+	    }
 
       dend = in_ptr + nfloat;
 
@@ -286,16 +288,16 @@ void dsp::Detection::square_law ()
     {
       for (unsigned ichan=0; ichan<loop_nchan; ichan++)
       {
-	register float* p0 = output->get_datptr (ichan, 0);
-	register float* p1 = output->get_datptr (ichan, 1);
-	const register float* pend = p0 + output->get_ndat();
+      	register float* p0 = output->get_datptr (ichan, 0);
+	      register float* p1 = output->get_datptr (ichan, 1);
+	      const register float* pend = p0 + output->get_ndat();
 	
-	while (p0!=pend)
-	  {
-	    *p0 += *p1;
-	    p0 ++;
-	    p1 ++;
-	  }
+	      while (p0!=pend)
+	      {
+	        *p0 += *p1;
+	        p0 ++;
+	        p1 ++;
+	      }
       }
     }
     else
@@ -307,12 +309,12 @@ void dsp::Detection::square_law ()
       const register float* pend = pout + output->get_ndat() * nchan;
 	
       while (pout!=pend)
-	{
-	  *pout = *p0 + *p1;
-	  *pout ++;
-	  p0 += 2;
-	  p1 += 2;
-	}
+	    {
+	      *pout = *p0 + *p1;
+	      *pout ++;
+	      p0 += 2;
+	      p1 += 2;
+	    }
     }
   } 
 }
@@ -346,6 +348,8 @@ void dsp::Detection::polarimetry () try
 
   uint64_t ndat = input->get_ndat();
   unsigned nchan = input->get_nchan();
+  unsigned ichan_start = input->get_ichan_start();
+  unsigned nchan_bundle = input->get_nchan_bundle();
 
   uint64_t required_space = 0;
   uint64_t copy_bytes = 0;
@@ -380,7 +384,7 @@ void dsp::Detection::polarimetry () try
 
   float* r[4];
 
-  for (unsigned ichan=0; ichan<nchan; ichan++)
+  for (unsigned ichan=ichan_start; ichan<(ichan_start+nchan_bundle); ichan++)
   {
     const float* p = input->get_datptr (ichan, 0);
     const float* q = input->get_datptr (ichan, 1);

--- a/Signal/General/DetectionCUDA.cu
+++ b/Signal/General/DetectionCUDA.cu
@@ -132,7 +132,8 @@ void CUDA::DetectionEngine::polarimetry (unsigned ndim,
 		 "cannot handle ndim=%u != 2", ndim);
 
   uint64_t ndat = input->get_ndat ();
-  unsigned nchan = input->get_nchan ();
+  unsigned ichan_start = input->get_ichan_start();
+  unsigned nchan_bundle = input->get_nchan_bundle();
 
   if (ndat != output->get_ndat ())
     throw Error (InvalidParam, "CUDA::DetectionEngine::polarimetry",
@@ -141,11 +142,11 @@ void CUDA::DetectionEngine::polarimetry (unsigned ndim,
 
   unsigned ichan=0, ipol=0;
 
-  const float* input_base = input->get_datptr (ichan=0, ipol=0);
-  uint64_t input_span = input->get_datptr (ichan=0, ipol=1) - input_base;
+  const float* input_base = input->get_datptr (ichan=ichan_start, ipol=0);
+  uint64_t input_span = input->get_datptr (ichan=ichan_start, ipol=1) - input_base;
 
-  float* output_base = output->get_datptr (ichan=0, ipol=0);
-  uint64_t output_span = output->get_datptr (ichan=0, ipol=1) - output_base;
+  float* output_base = output->get_datptr (ichan=ichan_start, ipol=0);
+  uint64_t output_span = output->get_datptr (ichan=ichan_start, ipol=1) - output_base;
 
   if (dsp::Operation::verbose)
     cerr << "CUDA::DetectionEngine::polarimetry ndim=" << output->get_ndim () 
@@ -156,7 +157,7 @@ void CUDA::DetectionEngine::polarimetry (unsigned ndim,
          << " output.span=" << output_span << endl;
 
   dim3 threads (128);
-  dim3 blocks (ndat/threads.x, nchan);
+  dim3 blocks (ndat/threads.x, nchan_bundle);
 
   if (ndat % threads.x)
     blocks.x ++;

--- a/Signal/General/FilterbankCUDA.cu
+++ b/Signal/General/FilterbankCUDA.cu
@@ -205,8 +205,9 @@ void CUDA::FilterbankEngine::perform (const dsp::TimeSeries * in, dsp::TimeSerie
   verbose = dsp::Operation::record_time || dsp::Operation::verbose;
 
   const unsigned npol = in->get_npol();
-  const unsigned input_nchan = in->get_nchan();
-  const unsigned output_nchan = out->get_nchan();
+  const unsigned input_nchan_bundle = in->get_nchan_bundle();
+  const unsigned input_ichan_start = in->get_ichan_start();
+  const unsigned output_ichan_start = out->get_ichan_start();
  
   // counters
   unsigned ipol, ichan;
@@ -225,14 +226,15 @@ void CUDA::FilterbankEngine::perform (const dsp::TimeSeries * in, dsp::TimeSerie
   float * input_ptr;
   uint64_t output_span;
 
-  DEBUG("CUDA::FilterbankEngine::perform input_nchan=" << input_nchan);
+  DEBUG("CUDA::FilterbankEngine::perform input_nchan_bundle=" << input_nchan_bundle);
+  DEBUG("CUDA::FilterbankEngine::perform input_ichan_start=" << input_ichan_start);
   DEBUG("CUDA::FilterbankEngine::perform npol=" << npol);
   DEBUG("CUDA::FilterbankEngine::perform npart=" << npart);
   DEBUG("CUDA::FilterbankEngine::perform nkeep=" << nkeep);
   DEBUG("CUDA::FilterbankEngine::perform in_step=" << in_step);
   DEBUG("CUDA::FilterbankEngine::perform out_step=" << out_step);
 
-  for (ichan=0; ichan<input_nchan; ichan++)
+  for (ichan=input_ichan_start; ichan<(input_ichan_start+input_nchan_bundle); ichan++)
   {
     for (ipol=0; ipol < npol; ipol++)
     {
@@ -286,7 +288,8 @@ void CUDA::FilterbankEngine::perform (const dsp::TimeSeries * in, dsp::TimeSerie
         if (out)
         {
           output_ptr = out->get_datptr (ichan*nchan_subband, ipol) + out_offset;
-          output_span = out->get_datptr (1, ipol) - out->get_datptr (0, ipol);
+          output_span = out->get_datptr (output_ichan_start+1, ipol) -
+                        out->get_datptr (output_ichan_start, ipol);
 
           const float2* input = cscratch + nfilt_pos;
           unsigned input_stride = freq_res;

--- a/Signal/General/FilterbankCUDA.cu
+++ b/Signal/General/FilterbankCUDA.cu
@@ -273,7 +273,7 @@ void CUDA::FilterbankEngine::perform (const dsp::TimeSeries * in, dsp::TimeSerie
         if (out)
         {
           output_ptr = out->get_datptr (ichan*nchan_subband, ipol) + out_offset;
-          output_span = out->get_datptr (ichan*nchan_subband+1, ipol) - out->get_datptr (ichan*nchan_subband, ipol);
+          output_span = out->get_datptr (1, ipol) - out->get_datptr (0, ipol);
 
           const float2* input = cscratch + nfilt_pos;
           unsigned input_stride = freq_res;

--- a/Signal/General/FilterbankCUDA.cu
+++ b/Signal/General/FilterbankCUDA.cu
@@ -113,12 +113,15 @@ void CUDA::FilterbankEngine::setup (dsp::Filterbank* filterbank)
 
   DEBUG("CUDA::FilterbankEngine::setup fwd FFT plan set");
 
+  // if inverse FFT is necessary
   if (freq_res > 1)
   {
-    result = cufftPlan1d (&plan_bwd, freq_res, CUFFT_C2C, nchan_subband);
+    int n[1] = { freq_res };
+    result = cufftPlanMany (&plan_bwd, 1, n, NULL, NULL, NULL, NULL, NULL,
+                            NULL, CUFFT_C2C, nchan_subband);
     if (result != CUFFT_SUCCESS)
-      throw CUFFTError (result, "CUDA::FilterbankEngine::setup", 
-			"cufftPlan1d(plan_bwd)");
+      throw CUFFTError (result, "CUDA::FilterbankEngine::setup",
+            "cufftPlanMany(plan_bwd)");
 
     // optimal performance for CUFFT regarding data layout
     result = cufftSetCompatibilityMode(plan_bwd, CUFFT_COMPATIBILITY_FFTW_PADDING);

--- a/Signal/General/FilterbankCUDA.cu
+++ b/Signal/General/FilterbankCUDA.cu
@@ -117,8 +117,8 @@ void CUDA::FilterbankEngine::setup (dsp::Filterbank* filterbank)
   if (freq_res > 1)
   {
     int n[1] = { freq_res };
-    result = cufftPlanMany (&plan_bwd, 1, n, NULL, NULL, NULL, NULL, NULL,
-                            NULL, CUFFT_C2C, nchan_subband);
+    result = cufftPlanMany (&plan_bwd, 1, n, NULL, 0, 0, NULL, 0, 0,
+                            CUFFT_C2C, nchan_subband);
     if (result != CUFFT_SUCCESS)
       throw CUFFTError (result, "CUDA::FilterbankEngine::setup",
             "cufftPlanMany(plan_bwd)");

--- a/Signal/General/FilterbankCUDA.cu
+++ b/Signal/General/FilterbankCUDA.cu
@@ -100,7 +100,7 @@ void CUDA::FilterbankEngine::setup (dsp::Filterbank* filterbank)
 			"cufftPlan1d(plan_fwd, CUFFT_C2C)");
   }
 
-  result = cufftSetCompatibilityMode(plan_fwd, CUFFT_COMPATIBILITY_NATIVE);
+  result = cufftSetCompatibilityMode(plan_fwd, CUFFT_COMPATIBILITY_FFTW_PADDING);
   if (result != CUFFT_SUCCESS)
     throw CUFFTError (result, "CUDA::FilterbankEngine::setup",
 		      "cufftSetCompatibilityMode(plan_fwd)");
@@ -121,7 +121,7 @@ void CUDA::FilterbankEngine::setup (dsp::Filterbank* filterbank)
 			"cufftPlan1d(plan_bwd)");
 
     // optimal performance for CUFFT regarding data layout
-    result = cufftSetCompatibilityMode(plan_bwd, CUFFT_COMPATIBILITY_NATIVE);
+    result = cufftSetCompatibilityMode(plan_bwd, CUFFT_COMPATIBILITY_FFTW_PADDING);
     if (result != CUFFT_SUCCESS)
       throw CUFFTError (result, "CUDA::FilterbankEngine::setup",
 			"cufftSetCompatibilityMode(plan_bwd)");

--- a/Signal/General/SingleThread.C
+++ b/Signal/General/SingleThread.C
@@ -240,9 +240,6 @@ void dsp::SingleThread::construct () try
     if (config->get_total_nthread() > 1)
       config->input_buffering = false;
 
-    //if (thread_id == 0)
-    //  cudaStreamCreate(manager->get_input_stream_ptr());
-
     int device = config->cuda_device[thread_id];
     cerr << "dspsr: thread " << thread_id
          << " using CUDA device " << device << endl;

--- a/Signal/General/SingleThread.C
+++ b/Signal/General/SingleThread.C
@@ -59,6 +59,7 @@ dsp::SingleThread::SingleThread ()
   input_context = 0;
   gpu_stream = undefined_stream;
   input_event = (void*) 0;
+  input_bundle = 0;
 }
 
 dsp::SingleThread::~SingleThread ()
@@ -142,11 +143,11 @@ void dsp::SingleThread::share (SingleThread* other)
 
     if (!trans)
       throw Error (InvalidState, "dsp::SingleThread::share",
-		   "mismatched operation type");
+                   "mismatched operation type");
 
     if (!trans->has_buffering_policy())
       throw Error (InvalidState, "dsp::SingleThread::share",
-		   "mismatched buffering policy");
+                   "mismatched buffering policy");
 
     if (Operation::verbose)
       cerr << "dsp::SingleThread::share sharing buffering policy of "
@@ -284,20 +285,23 @@ void dsp::SingleThread::construct () try
 
       unpacked->set_memory (new CUDA::PinnedMemory);
 
-      TransferCUDA* transfer;
+      TransferCUDA* transfer = new TransferCUDA (stream);
       if (config->use_input_stream)
       {
+        if (Operation::verbose)
+          cerr << "SingleThread: setting input stream" << endl;
         // Create an event that signals the completion of the CUDA transfer
         cudaEventCreate( reinterpret_cast<cudaEvent_t*>(&input_event) );
-        transfer = new TransferCUDA (stream,
-          static_cast<cudaStream_t>(input_stream), static_cast<cudaEvent_t>(input_event));
+        transfer->set_input_stream(static_cast<cudaStream_t>(input_stream),
+                                   static_cast<cudaEvent_t>(input_event));
       }
-      else
-        transfer = new TransferCUDA (stream);
       transfer->set_kind( cudaMemcpyHostToDevice );
       transfer->set_input( unpacked );
 
+      // reusing input variable for output now that input is set
       unpacked = new_time_series (false);
+      // input has 1 bundle, output has whatever number user set
+      unpacked->set_total_nbundle(config->nbundle);
       unpacked->set_memory (device_memory);
       transfer->set_output( unpacked );
 
@@ -325,7 +329,10 @@ void dsp::SingleThread::prepare ()
     insert_dump_point (config->dump_before[idump]);
 
   for (unsigned iop=0; iop < operations.size(); iop++)
+  {
+    operations[iop]->set_input_bundle(0, config->nbundle);
     operations[iop]->prepare ();
+  }
 }
 
 void dsp::SingleThread::insert_dump_point (const std::string& transform_name)
@@ -338,8 +345,8 @@ void dsp::SingleThread::insert_dump_point (const std::string& transform_name)
     {
       Xform* xform = dynamic_cast<Xform*>( operations[iop].get() );
       if (!xform)
-	throw Error (InvalidParam, "dsp::SingleThread::insert_dump_point",
-		     transform_name + " does not have TimeSeries input");
+        throw Error (InvalidParam, "dsp::SingleThread::insert_dump_point",
+                     transform_name + " does not have TimeSeries input");
 
       string filename = "pre_" + transform_name;
 
@@ -383,9 +390,12 @@ void dsp::SingleThread::run () try
     if (log)
     {
       cerr << "dsp::SingleThread::run setup "
-	   << operations[iop]->get_name() << endl;
+           << operations[iop]->get_name() << endl;
       operations[iop] -> set_cerr (*log);
     }
+    
+    // All threads start at input bundle 0
+    operations[iop]->set_input_bundle(0, config->nbundle);
 
     if (!operations[iop] -> scratch_was_set ())
       operations[iop] -> set_scratch (scratch);
@@ -411,56 +421,69 @@ void dsp::SingleThread::run () try
 
   while (!finished)
   {
-    while (!input->eod())
+    while (!(input->eod() && input_bundle==0))
     {
+      unsigned current_input_bundle = input_bundle;
+      increment_input_bundle();
+      if (Operation::verbose)
+        cerr << "dsp::SingleThread::run"
+             << " thread_id=" << thread_id
+             << " current input_bundle=" << current_input_bundle
+             << " next input_bundle=" << input_bundle << endl;
       for (unsigned iop=0; iop < operations.size(); iop++) try
       {
-	if (Operation::verbose)
-	  cerr << "dsp::SingleThread::run calling "
-	       << operations[iop]->get_name() << endl;
+        operations[iop]->set_input_bundle(current_input_bundle, config->nbundle);
+        // Ensure that operations[0], loading from input and unpacking, only
+        // happens when input_bundle is 0
+        if (!(iop == 0 && current_input_bundle != 0))
+        {
+          if (Operation::verbose)
+            cerr << "dsp::SingleThread::run calling "
+                 << operations[iop]->get_name()
+                 << " (bundle " << current_input_bundle << ")" << endl;
 
-  // If the CUDA transfers are in their own stream, the Filterbank step will
-  // begin too soon unless told to wait for an event
-  if (config->use_input_stream && operations[iop]->get_name() == "Filterbank")
-    cudaStreamWaitEvent(static_cast<cudaStream_t>(gpu_stream),
-                        static_cast<cudaEvent_t>(input_event), 0);
+          // If the CUDA transfers are in their own stream, the Filterbank step
+          // will begin too soon unless told to wait for an event
+          if (config->use_input_stream && operations[iop]->get_name() == "Filterbank")
+            cudaStreamWaitEvent(static_cast<cudaStream_t>(gpu_stream),
+                                static_cast<cudaEvent_t>(input_event), 0);
 
-	operations[iop]->operate ();
+          operations[iop]->operate ();
 
-	if (Operation::verbose)
-	  cerr << "dsp::SingleThread::run "
-	       << operations[iop]->get_name() << " done" << endl;
-
+          if (Operation::verbose)
+            cerr << "dsp::SingleThread::run "
+                 << operations[iop]->get_name() << " done" << endl;
+        }
       }
       catch (Error& error)
       {
-	if (error.get_code() == EndOfFile)
-	  break;
+        if (error.get_code() == EndOfFile)
+          break;
 
-	end_of_data ();
+        end_of_data ();
 
-	throw error += "dsp::SingleThread::run";
+        throw error += "dsp::SingleThread::run";
       }
 
       block++;
 
       if (thread_id==0 && config->report_done)
       {
-	double seconds = input->tell_seconds();
-	int64_t decisecond = int64_t( seconds * 10 );
+        double seconds = input->tell_seconds();
+        int64_t decisecond = int64_t( seconds * 10 );
 
-	if (decisecond > last_decisecond)
-	{
-	  last_decisecond = decisecond;
-	  cerr << "Finished " << decisecond/10.0 << " s";
+        if (decisecond > last_decisecond)
+        {
+          last_decisecond = decisecond;
+          cerr << "Finished " << decisecond/10.0 << " s";
 
-	  if (nblocks_tot)
-	    cerr << " ("
-		 << int (100.0*input->tell()/float(input->get_total_samples()))
-		 << "%)";
+          if (nblocks_tot)
+            cerr << " ("
+                 << int (100.0*input->tell()/float(input->get_total_samples()))
+                 << "%)";
 
-	  cerr << "   \r";
-	}
+          cerr << "   \r";
+        }
       }
     }
 
@@ -472,30 +495,30 @@ void dsp::SingleThread::run () try
 
       if (config->repeated == 0 && input->tell() != 0)
       {
-	// cerr << "dspsr: do it again" << endl;
-	File* file = dynamic_cast<File*> (input);
-	if (file)
-	{
-	  finished = false;
-	  string filename = file->get_filename();
-	  file->close();
-	  // cerr << "file closed" << endl;
-	  file->open(filename);
-	  // cerr << "file opened" << endl;
-	  config->repeated = 1;
+        // cerr << "dspsr: do it again" << endl;
+        File* file = dynamic_cast<File*> (input);
+        if (file)
+        {
+          finished = false;
+          string filename = file->get_filename();
+          file->close();
+          // cerr << "file closed" << endl;
+          file->open(filename);
+          // cerr << "file opened" << endl;
+          config->repeated = 1;
 
-	  if (config->input_prepare)
-	    config->input_prepare (file);
+          if (config->input_prepare)
+            config->input_prepare (file);
 
-	}
+        }
       }
       else if (config->repeated)
       {
-	config->repeated ++;
-	finished = false;
+        config->repeated ++;
+        finished = false;
 
-	if (config->repeated == config->get_total_nthread())
-	  config->repeated = 0;
+        if (config->repeated == config->get_total_nthread())
+          config->repeated = 0;
       }
     }
   }
@@ -610,6 +633,14 @@ catch (Error& error)
   throw error += "dsp::SingleThread::finish";
 }
 
+void dsp::SingleThread::increment_input_bundle ()
+{
+  if (input_bundle < config->nbundle-1)
+    input_bundle += 1;
+  else
+    input_bundle = 0;
+}
+
 void dsp::SingleThread::end_of_data ()
 {
   // do nothing by default
@@ -639,6 +670,9 @@ dsp::SingleThread::Config::Config ()
 
   // use input buffering
   input_buffering = true;
+
+  // by default, use full blocks of input channels
+  nbundle = 1;
 
   list_attributes = false;
 
@@ -796,6 +830,9 @@ void dsp::SingleThread::Config::add_options (CommandLine::Menu& menu)
 
   arg = menu.add (input_buffering, "overlap");
   arg->set_help ("disable input buffering");
+  
+  arg = menu.add (this, &Config::set_nbundle, "nbundle", "bundles");
+  arg->set_help ("process blocks of input channels in nbundle bundles");
 
   arg = menu.add (command_line_header, "header");
   arg->set_help ("command line arguments are header values (not filenames)");
@@ -813,7 +850,7 @@ void dsp::SingleThread::Config::add_options (CommandLine::Menu& menu)
   arg->set_help ("process only t=total seconds");
 
   arg = menu.add (&editor, &TextEditor<Observation>::add_commands,
-		  "set", "key=value");
+                  "set", "key=value");
   arg->set_help ("set observation attributes");
 
   arg = menu.add (list_attributes, "list");
@@ -865,6 +902,11 @@ void dsp::SingleThread::Config::add_options (CommandLine::Menu& menu)
 
 }
 
+void dsp::SingleThread::Config::set_nbundle (unsigned _nbundle)
+{
+  nbundle = _nbundle;
+}
+
 void dsp::SingleThread::Config::set_quiet ()
 {
   dsp::set_verbosity (0);
@@ -893,15 +935,15 @@ void dsp::SingleThread::Config::set_fft_library (string fft_lib)
 
     if (nlib == 1)
       std::cerr << "There is 1 available FFT library: "
-		<< FTransform::get_library_name (0) << endl;
+                << FTransform::get_library_name (0) << endl;
     else
     {
       std::cerr << "There are " << nlib << " available FFT libraries:";
       for (unsigned ilib=0; ilib < nlib; ilib++)
-	std::cerr << " " << FTransform::get_library_name (ilib);
+        std::cerr << " " << FTransform::get_library_name (ilib);
 
       std::cerr << "\nThe default FFT library is "
-		<< FTransform::get_library() << endl;
+                << FTransform::get_library() << endl;
     }
     exit (0);
   }

--- a/Signal/General/SingleThread.C
+++ b/Signal/General/SingleThread.C
@@ -263,6 +263,8 @@ void dsp::SingleThread::construct () try
       if (Operation::verbose)
         cerr << "SingleThread: unpack on CPU" << endl;
 
+      unpacked->set_memory (new CUDA::PinnedMemory);
+
       TransferCUDA* transfer = new TransferCUDA (stream);
       transfer->set_kind( cudaMemcpyHostToDevice );
       transfer->set_input( unpacked );

--- a/Signal/General/TransferCUDA.C
+++ b/Signal/General/TransferCUDA.C
@@ -19,17 +19,7 @@ dsp::TransferCUDA::TransferCUDA(cudaStream_t _stream)
   stream = _stream;
   input_stream = _stream;
   kind = cudaMemcpyHostToDevice;
-}
-
-//! Associate cudaEvent with the transfer
-dsp::TransferCUDA::TransferCUDA(cudaStream_t _stream,
-                                cudaStream_t _input_stream, cudaEvent_t _event)
-  : Transformation<TimeSeries,TimeSeries> ("CUDA::Transfer", outofplace)
-{
-  stream = _stream;
-  input_stream = _input_stream;
-  kind = cudaMemcpyHostToDevice;
-  event = _event;
+  event = 0;
 }
 
 //! Do stuff
@@ -45,29 +35,36 @@ void dsp::TransferCUDA::transformation ()
   else
     cudaThreadSynchronize();
 
+  unsigned ichan_start = output->get_ichan_start();
+  
+  const float* input_start = input->get_datptr(ichan_start, 0);
+  const unsigned input_nfloat = input->get_datptr(input->get_nchan()/nbundle, 0) - input->get_datptr(0,0);
+  
   if (verbose)
   {
     cerr << "dsp::TransferCUDA::transformation input ndat="
          << input->get_ndat() << " ndim=" << input->get_ndim();
     if (input->get_npol() > 1)
-      cerr << " span=" << input->get_datptr (0,1) - input->get_datptr(0,0);
-    cerr << " offset=" << input->get_datptr(0,0) - (float*)input->internal_get_buffer() << endl;
+      cerr << " span=" << input->get_datptr (ichan_start,1) - input->get_datptr(ichan_start,0);
+    cerr << " offset=" << input->get_datptr(ichan_start,0) - (float*)input->internal_get_buffer() << endl;
   }
 
   cudaError error;
   if (input_stream)
   {
     error = cudaMemcpyAsync (output->internal_get_buffer(),
-                             input->internal_get_buffer(),
-                             input->internal_get_size(),
+                             input_start,
+                             input_nfloat*sizeof(float),
                              kind,
                              input_stream);
-    cudaEventRecord(event, input_stream);
+    if (event)
+      cudaEventRecord(event, input_stream);
   }
   else
     error = cudaMemcpy (output->internal_get_buffer(),
-                             input->internal_get_buffer(),
-                             input->internal_get_size(), kind);
+                        input_start,
+                        input_nfloat*sizeof(float),
+                        kind);
   if (error != cudaSuccess)
     throw Error (InvalidState, "dsp::TransferCUDA::transformation",
                  cudaGetErrorString (error));
@@ -77,9 +74,9 @@ void dsp::TransferCUDA::transformation ()
     cerr << "dsp::TransferCUDA::transformation output ndat="
        << output->get_ndat() << " ndim=" << output->get_ndim();
     if (output->get_npol() > 1)
-      cerr << " span=" << output->get_datptr (0, 1) - output->get_datptr(0,0);
+      cerr << " span=" << output->get_datptr (ichan_start, 1) - output->get_datptr(ichan_start,0);
 
-    cerr << " offset=" << output->get_datptr(0,0) - (float*)output->internal_get_buffer() << endl;
+    cerr << " offset=" << output->get_datptr(ichan_start,0) - (float*)output->internal_get_buffer() << endl;
   }
 }
 
@@ -88,4 +85,12 @@ void dsp::TransferCUDA::prepare ()
   output->set_match( const_cast<TimeSeries*>(input.get()) );
   output->internal_match( input );
   output->copy_configuration( input );
+  output->set_total_nbundle( nbundle );
+  output->set_input_bundle( input_bundle );
+}
+
+void dsp::TransferCUDA::set_input_stream (cudaStream_t _input_stream, cudaEvent_t _event)
+{
+  input_stream = _input_stream;
+  event = _event;
 }

--- a/Signal/General/dsp/Filterbank.h
+++ b/Signal/General/dsp/Filterbank.h
@@ -67,6 +67,9 @@ namespace dsp {
     class Engine;
     void set_engine (Engine*);
 
+    void set_d_kernel_gpu_ptr (void** dk_ptr) { d_kernel_gpu_ptr = dk_ptr; }
+    void** get_d_kernel_gpu_ptr () { return d_kernel_gpu_ptr; }
+
   protected:
 
     //! Perform the convolution transformation on the input TimeSeries
@@ -91,6 +94,9 @@ namespace dsp {
 
     //! Interface to alternate processing engine (e.g. GPU)
     Reference::To<Engine> engine;
+    
+    // Points to d_kernel_gpu defined in LoadToFoldConfig
+    void** d_kernel_gpu_ptr;
 
   private:
 

--- a/Signal/General/dsp/FilterbankCUDA.h
+++ b/Signal/General/dsp/FilterbankCUDA.h
@@ -35,8 +35,6 @@ namespace CUDA
   //! Discrete convolution filterbank step implemented using CUDA streams
   class FilterbankEngine : public dsp::Filterbank::Engine
   {
-    unsigned nstream;
-
   public:
 
     //! Default Constructor

--- a/Signal/General/dsp/FilterbankCUDA.h
+++ b/Signal/General/dsp/FilterbankCUDA.h
@@ -35,6 +35,8 @@ namespace CUDA
   //! Discrete convolution filterbank step implemented using CUDA streams
   class FilterbankEngine : public dsp::Filterbank::Engine
   {
+    unsigned nstream;
+    
   public:
 
     //! Default Constructor

--- a/Signal/General/dsp/SingleThread.h
+++ b/Signal/General/dsp/SingleThread.h
@@ -214,6 +214,10 @@ namespace dsp {
     void set_cuda_device (std::string);
     unsigned get_cuda_ndevice () const { return cuda_device.size(); }
 
+    //! set the number of kernel streams per cuda device
+    void set_cuda_nstream (unsigned);
+    unsigned get_cuda_nstream () const { return nstream; }
+
     //! set the number of CPU threads to be used
     void set_nthread (unsigned);
 
@@ -257,6 +261,9 @@ namespace dsp {
 
     //! CUDA devices on which computations will take place
     std::vector<unsigned> cuda_device;
+
+    //! number of kernel streams per cuda device
+    unsigned nstream;
 
     //! application can make use of multiple cores
     bool can_thread;

--- a/Signal/General/dsp/SingleThread.h
+++ b/Signal/General/dsp/SingleThread.h
@@ -44,7 +44,7 @@ namespace dsp {
 
     //! Constructor
     SingleThread ();
-    
+
     //! Destructor
     ~SingleThread ();
 
@@ -87,6 +87,11 @@ namespace dsp {
     unsigned thread_id;
     void set_affinity (int core);
 
+    void set_input_stream (void* _input_stream) { input_stream = _input_stream; }
+
+    // Placeholder for CUDA event signaling a completed input memory transfer
+    void* input_event;
+
   protected:
 
     //! Any special operations that must be performed at the end of data
@@ -106,7 +111,7 @@ namespace dsp {
 	Prepared,    //! preparations completed
 	Run,         //! processing started
 	Done,        //! processing completed
-	Joined       //! completion acknowledged 
+	Joined       //! completion acknowledged
       };
 
     //! Processing state
@@ -135,6 +140,7 @@ namespace dsp {
 
     //! Create a new TimeSeries instance
     TimeSeries* new_time_series ();
+    TimeSeries* new_time_series (bool increase_buffers);
     TimeSeries* new_TimeSeries () { return new_time_series(); }
 
     //! The operations to be performed
@@ -151,6 +157,9 @@ namespace dsp {
 
     Reference::To<Memory> device_memory;
     void* gpu_stream;
+    
+    // Placeholder for CUDA stream in which input memory transfers occur
+    void* input_stream;
 
   };
 
@@ -170,7 +179,7 @@ namespace dsp {
 
     //! Prepare the input according to the configuration
     virtual void prepare (Input*);
-    
+
     //! external function used to prepare the input each time it is opened
     Functor< void(Input*) > input_prepare;
 
@@ -268,8 +277,3 @@ namespace dsp {
 }
 
 #endif // !defined(__SingleThread_h)
-
-
-
-
-

--- a/Signal/General/dsp/SingleThread.h
+++ b/Signal/General/dsp/SingleThread.h
@@ -92,6 +92,9 @@ namespace dsp {
     // Placeholder for CUDA event signaling a completed input memory transfer
     void* input_event;
 
+    // Increases input_bundle by 1 or sets it back to 0   
+    void increment_input_bundle();
+
   protected:
 
     //! Any special operations that must be performed at the end of data
@@ -103,15 +106,15 @@ namespace dsp {
     //! Processing thread states
     enum State
       {
-	Fail,        //! an error has occurred
-	Idle,        //! nothing happening
-	Construct,   //! request to construct
-	Constructed, //! construction completed
-	Prepare,     //! request to prepare
-	Prepared,    //! preparations completed
-	Run,         //! processing started
-	Done,        //! processing completed
-	Joined       //! completion acknowledged
+        Fail,        //! an error has occurred
+        Idle,        //! nothing happening
+        Construct,   //! request to construct
+        Constructed, //! construction completed
+        Prepare,     //! request to prepare
+        Prepared,    //! preparations completed
+        Run,         //! processing started
+        Done,        //! processing completed
+        Joined       //! completion acknowledged
       };
 
     //! Processing state
@@ -161,6 +164,9 @@ namespace dsp {
     // Placeholder for CUDA stream in which input memory transfers occur
     void* input_stream;
 
+    // Current input bundle
+    unsigned input_bundle;
+
   };
 
   //! Per-thread configuration options
@@ -209,6 +215,10 @@ namespace dsp {
 
     //! run repeatedly on the same input
     bool run_repeatedly;
+
+    //! set number of bundles into which input channels are divided
+    void set_nbundle (unsigned);
+    unsigned get_nbundle () const { return nbundle; }
 
     //! set the cuda devices to be used
     void set_cuda_device (std::string);
@@ -275,6 +285,9 @@ namespace dsp {
 
     //! CPUs on which threads will run
     std::vector<unsigned> affinity;
+
+    //! Number of bundles into which input channels are divided
+    unsigned nbundle;
 
     //! number of CPU threads
     unsigned nthread;

--- a/Signal/General/dsp/SingleThread.h
+++ b/Signal/General/dsp/SingleThread.h
@@ -233,6 +233,11 @@ namespace dsp {
     //! use input-buffering to compensate for operation edge effects
     bool input_buffering;
 
+    // keep input copies onto cuda device in their own stream so they
+    // don't overlap (allows them to be faster and encourages staggered
+    // kernel operations in other streams)
+    bool use_input_stream;
+
     //! use weighted time series to flag bad data
     bool weighted_time_series;
 

--- a/Signal/General/dsp/TransferCUDA.h
+++ b/Signal/General/dsp/TransferCUDA.h
@@ -23,6 +23,10 @@ namespace dsp {
     //! Default constructor - always out of place
     TransferCUDA(cudaStream_t _stream);
 
+    //! Constructor with input stream and completion event
+    TransferCUDA(cudaStream_t _stream, cudaStream_t _input_stream,
+                 cudaEvent_t _event);
+
     void set_kind (cudaMemcpyKind k) { kind = k; }
     void prepare ();
 
@@ -36,6 +40,10 @@ namespace dsp {
     cudaMemcpyKind kind;
 
     cudaStream_t stream;
+
+    cudaStream_t input_stream;
+
+    cudaEvent_t event;
 
   };
 

--- a/Signal/General/dsp/TransferCUDA.h
+++ b/Signal/General/dsp/TransferCUDA.h
@@ -23,12 +23,12 @@ namespace dsp {
     //! Default constructor - always out of place
     TransferCUDA(cudaStream_t _stream);
 
-    //! Constructor with input stream and completion event
-    TransferCUDA(cudaStream_t _stream, cudaStream_t _input_stream,
-                 cudaEvent_t _event);
-
     void set_kind (cudaMemcpyKind k) { kind = k; }
     void prepare ();
+    
+    // If transferring all input in its own stream, need the stream and an event
+    // signaling transfer completion
+    void set_input_stream (cudaStream_t _input_stream, cudaEvent_t _event);
 
     Operation::Function get_function () const { return Operation::Structural; }
 

--- a/Signal/Pulsar/FoldCUDA.cu
+++ b/Signal/Pulsar/FoldCUDA.cu
@@ -177,9 +177,12 @@ void CUDA::FoldEngine::send_binplan ()
   cudaError error;
 
   if (stream)
+	{
+		cudaStreamSynchronize(stream);
     error = cudaMemcpyAsync (d_bin, binplan, mem_size,
 			     cudaMemcpyHostToDevice, stream);
-  else
+  }
+	else
     error = cudaMemcpy (d_bin, binplan, mem_size, cudaMemcpyHostToDevice);
 
   if (error != cudaSuccess)

--- a/Signal/Pulsar/LoadToFold1.C
+++ b/Signal/Pulsar/LoadToFold1.C
@@ -353,6 +353,13 @@ void dsp::LoadToFold::construct () try
     // software filterbank constructor
     if (!filterbank)
       filterbank = config->filterbank.create();
+      
+#if HAVE_CUDA
+    // This allows multiple streams on GPU to share one copy of the dedispersion
+    // kernel.  NOTE: Like with the input stream, this should be updated to
+    // check for multiple devices and copy once for each.
+    filterbank->set_d_kernel_gpu_ptr(&(config->d_kernel_gpu));
+#endif
 
     if (!config->input_buffering)
       filterbank->set_buffering_policy (NULL);

--- a/Signal/Pulsar/LoadToFold1.C
+++ b/Signal/Pulsar/LoadToFold1.C
@@ -121,7 +121,8 @@ void dsp::LoadToFold::construct () try
   SingleThread::construct ();
 
   #if HAVE_CUDA
-  bool run_on_gpu = thread_id < config->get_cuda_ndevice();
+  bool run_on_gpu = thread_id < config->get_cuda_ndevice()
+                                * config->get_cuda_nstream();
   cudaStream_t stream = reinterpret_cast<cudaStream_t>( gpu_stream );
   #endif
 
@@ -1096,7 +1097,8 @@ catch (Error& error)
 void dsp::LoadToFold::configure_detection (Detection* detect, int noperations)
 {
 #if HAVE_CUDA
-  bool run_on_gpu = thread_id < config->get_cuda_ndevice();
+  bool run_on_gpu = thread_id < config->get_cuda_ndevice()
+                                * config->get_cuda_nstream();
   cudaStream_t stream = reinterpret_cast<cudaStream_t>( gpu_stream );
 
   if (run_on_gpu)

--- a/Signal/Pulsar/LoadToFold1.C
+++ b/Signal/Pulsar/LoadToFold1.C
@@ -107,12 +107,23 @@ unsigned count (const std::vector<T>& data, T element)
 
 void dsp::LoadToFold::construct () try
 {
+  #if HAVE_CUDA
+  // NOTE: probably want to set this on a device-by-device basis (since multiple
+  // gpu streams are presently set by setting the same device multiple times,
+  // this is written assuming all listed devices are the same)
+  if ( !config->input_stream )
+    cudaStreamCreate( reinterpret_cast<cudaStream_t*>(&config->input_stream) );
+  #endif
+
+  // Separate stream for input memcpy (gpu) allows better copy/execution
+  // parallelization.  This does nothing important if gpus are not being used.
+  SingleThread::set_input_stream(config->input_stream);
   SingleThread::construct ();
 
-#if HAVE_CUDA
+  #if HAVE_CUDA
   bool run_on_gpu = thread_id < config->get_cuda_ndevice();
   cudaStream_t stream = reinterpret_cast<cudaStream_t>( gpu_stream );
-#endif
+  #endif
 
   if (manager->get_info()->get_detected())
   {
@@ -159,7 +170,7 @@ void dsp::LoadToFold::construct () try
     if (config->times_minimum_nfft)
     {
       if (report_vitals)
-        cerr << "dspsr: setting filter length to minimum times " 
+        cerr << "dspsr: setting filter length to minimum times "
              << config->times_minimum_nfft << endl;
       kernel->set_times_minimum_nfft (config->times_minimum_nfft);
     }
@@ -218,20 +229,20 @@ void dsp::LoadToFold::construct () try
   if (!config->calibrator_database_filename.empty())
   {
     dsp::PolnCalibration* polcal = new PolnCalibration;
-   
+
     polcal-> set_database_filename (config->calibrator_database_filename);
 
     if (kernel)
     {
       if (!response_product)
         response_product = new ResponseProduct;
-    
+
       response_product->add_response (polcal);
       response_product->add_response (kernel);
-      
+
       response_product->set_copy_index (0);
       response_product->set_match_index (1);
-      
+
       response = response_product;
     }
   }
@@ -251,7 +262,7 @@ void dsp::LoadToFold::construct () try
     TimeSeries* skfilterbank_input = unpacked;
 
 #if HAVE_CUDA
-    if (run_on_gpu) 
+    if (run_on_gpu)
     {
       Unpacker* unpack_on_cpu = 0;
       unpack_on_cpu = manager->get_unpacker()->clone();
@@ -301,7 +312,7 @@ void dsp::LoadToFold::construct () try
     skdetector->set_thresholds (config->sk_m, config->sk_std_devs);
     if (config->sk_chan_start > 0 && config->sk_chan_end < config->filterbank.get_nchan())
       skdetector->set_channel_range (config->sk_chan_start, config->sk_chan_end);
-    skdetector->set_options (config->sk_no_fscr, config->sk_no_tscr, config->sk_no_ft); 
+    skdetector->set_options (config->sk_no_fscr, config->sk_no_tscr, config->sk_no_ft);
 
     skthread->append_operation (skdetector);
 
@@ -318,7 +329,7 @@ void dsp::LoadToFold::construct () try
     // we must return it to the required size for the SKFB
     if (!skresize)
       skresize = new Resize;
-    
+
     skresize->set_input(unpacked);
     skresize->set_output(unpacked);
     operations.push_back (skresize.get());
@@ -347,7 +358,7 @@ void dsp::LoadToFold::construct () try
 
     filterbank->set_input (unpacked);
     filterbank->set_output (convolved);
-    
+
     if (config->filterbank.get_convolve_when() == Filterbank::Config::During)
     {
       filterbank->set_response (response);
@@ -368,22 +379,22 @@ void dsp::LoadToFold::construct () try
   {
     if (!convolution)
       convolution = new Convolution;
-    
+
     convolution->set_response (response);
     if (!config->integration_turns)
       convolution->set_passband (passband);
-    
+
     if (filterbank_after_dedisp)
     {
-      convolution->set_input  (unpacked);  
+      convolution->set_input  (unpacked);
       convolution->set_output (unpacked);  // inplace
     }
     else
     {
-      convolution->set_input  (convolved);  
+      convolution->set_input  (convolved);
       convolution->set_output (convolved);  // inplace
     }
-    
+
     operations.push_back (convolution.get());
   }
 
@@ -405,10 +416,10 @@ void dsp::LoadToFold::construct () try
 
     if (!phased_filterbank)
     {
-      if (output_subints()) 
+      if (output_subints())
       {
 
-        Subint<PhaseLockedFilterbank> *sub_plfb = 
+        Subint<PhaseLockedFilterbank> *sub_plfb =
           new Subint<PhaseLockedFilterbank>;
 
         if (config->integration_length)
@@ -416,7 +427,7 @@ void dsp::LoadToFold::construct () try
           sub_plfb->set_subint_seconds (config->integration_length);
         }
 
-        else if (config->integration_turns) 
+        else if (config->integration_turns)
         {
           sub_plfb->set_subint_turns (config->integration_turns);
           sub_plfb->set_fractional_pulses (config->fractional_pulses);
@@ -465,7 +476,7 @@ void dsp::LoadToFold::construct () try
 
     return;
     // the phase-locked filterbank does its own detection and folding
-    
+
   }
 
   Reference::To<Fold> presk_fold;
@@ -473,7 +484,7 @@ void dsp::LoadToFold::construct () try
 
   // peform zapping based on the results of the SKFilterbank
   if (config->sk_zap)
-  { 
+  {
     if (config->nosk_too)
     {
       Detection* presk_detect = new Detection;
@@ -584,7 +595,7 @@ void dsp::LoadToFold::construct () try
   {
     if (Operation::verbose)
       cerr << "LoadToFold::construct fourth order moments" << endl;
-              
+
     FourthMoment* fourth = new FourthMoment;
     operations.push_back (fourth);
 
@@ -732,10 +743,10 @@ void dsp::LoadToFold::prepare ()
   {
     if ( config->excision_nsample )
       excision -> set_ndat_per_weight ( config->excision_nsample );
-  
+
     if ( config->excision_threshold > 0 )
       excision -> set_threshold ( config->excision_threshold );
-    
+
     if ( config->excision_cutoff >= 0 )
       excision -> set_cutoff_sigma ( config->excision_cutoff );
   }
@@ -811,10 +822,10 @@ void dsp::LoadToFold::prepare ()
 
   if (convolution)
   {
-    minimum_samples = convolution->get_minimum_samples () * 
+    minimum_samples = convolution->get_minimum_samples () *
       convolution->get_input()->get_nchan();
     if (report_vitals)
-      cerr << "dspsr: convolution requires at least " 
+      cerr << "dspsr: convolution requires at least "
            << minimum_samples << " samples" << endl;
 
     if (!config->input_buffering)
@@ -857,7 +868,7 @@ void dsp::LoadToFold::prepare ()
     skresize->set_resize_samples (skfb_increment);
 
     if (Operation::verbose)
-      cerr << "dsp::LoadToFold::prepare block_size will be adjusted by " 
+      cerr << "dsp::LoadToFold::prepare block_size will be adjusted by "
           << skfb_increment << " samples for SKFB" << endl;
   }
 
@@ -958,7 +969,7 @@ void dsp::LoadToFold::build_fold (TimeSeries* to_fold)
   }
 }
 
-dsp::PhaseSeriesUnloader* 
+dsp::PhaseSeriesUnloader*
 dsp::LoadToFold::get_unloader (unsigned ifold)
 {
   if (ifold == unloader.size())
@@ -990,7 +1001,7 @@ void dsp::LoadToFold::build_fold (Reference::To<Fold>& fold,
     {
       if (Operation::verbose)
 	cerr << "dsp::LoadToFold::build_fold prepare CyclicFold" << endl;
-      
+
       CyclicFold* cs = new CyclicFold;
       cs -> set_mover (config->cyclic_mover);
       cs -> set_nchan (config->cyclic_nchan);
@@ -1006,7 +1017,7 @@ void dsp::LoadToFold::build_fold (Reference::To<Fold>& fold,
       fold = new Fold;
     }
   }
-  else if (config->cyclic_nchan) 
+  else if (config->cyclic_nchan)
   {
     if (Operation::verbose)
       cerr << "dsp::LoadToFold::build_fold prepare Subint<CyclicFold>" << endl;
@@ -1020,29 +1031,29 @@ void dsp::LoadToFold::build_fold (Reference::To<Fold>& fold,
     if (config->integration_length)
     {
       subfold -> set_subint_seconds (config->integration_length);
-	
+
       if (config->minimum_integration_length > 0)
 	unloader->set_minimum_integration_length (config->minimum_integration_length);
     }
     else
-      throw Error (InvalidState, "dsp::LoadToFold::build_fold", 
+      throw Error (InvalidState, "dsp::LoadToFold::build_fold",
 		   "Single-pulse cyclic spectra not supported");
-    
+
     subfold -> set_unloader (unloader);
 
     fold = subfold;
   }
-  else 
+  else
   {
     if (Operation::verbose)
       cerr << "dsp::LoadToFold::build_fold prepare Subint<Fold>" << endl;
 
     Subint<Fold>* subfold = new Subint<Fold>;
-    
+
     if (config->integration_length)
     {
       subfold -> set_subint_seconds (config->integration_length);
-	
+
       if (config->minimum_integration_length > 0)
 	unloader->set_minimum_integration_length (config->minimum_integration_length);
     }
@@ -1095,7 +1106,7 @@ void dsp::LoadToFold::configure_detection (Detection* detect, int noperations)
   }
 #endif
 
-  if (manager->get_info()->get_npol() == 1) 
+  if (manager->get_info()->get_npol() == 1)
   {
     cerr << "Only single polarization detection available" << endl;
     detect->set_output_state( Signal::PP_State );
@@ -1141,7 +1152,7 @@ void dsp::LoadToFold::configure_detection (Detection* detect, int noperations)
 void dsp::LoadToFold::configure_fold (unsigned ifold, TimeSeries* to_fold)
 {
   Reference::To<ObservationChange> change;
-  
+
   if (ifold && ifold <= config->additional_pulsars.size())
   {
     change = new ObservationChange;
@@ -1152,21 +1163,21 @@ void dsp::LoadToFold::configure_fold (unsigned ifold, TimeSeries* to_fold)
   {
     if (!change)
       change = new ObservationChange;
-    
+
     Pulsar::Parameters* ephem = config->ephemerides[ifold];
     change->set_source( ephem->get_name() );
     change->set_dispersion_measure( get_dispersion_measure(ephem) );
-    
+
     fold[ifold]->set_pulsar_ephemeris ( config->ephemerides[ifold] );
   }
 
   if (ifold < config->predictors.size())
   {
     fold[ifold]->set_folding_predictor ( config->predictors[ifold] );
-    
+
     Pulsar::SimplePredictor* simple
       = dynamic_kast<Pulsar::SimplePredictor>( config->predictors[ifold] );
-    
+
     if (simple)
     {
       config->dispersion_measure = simple->get_dispersion_measure();
@@ -1183,38 +1194,38 @@ void dsp::LoadToFold::configure_fold (unsigned ifold, TimeSeries* to_fold)
 
       if (!change)
 	change = new ObservationChange;
-      
+
       change->set_source( simple->get_name() );
       change->set_dispersion_measure( simple->get_dispersion_measure() );
     }
-  }    
-  
+  }
+
   fold[ifold]->set_input (to_fold);
-  
+
   if (change)
     fold[ifold]->set_change (change);
-  
+
   if (ifold && ifold <= config->additional_pulsars.size())
   {
     if (!change)
       change = new ObservationChange;
-    
+
     /*
       If additional pulsar names have been specified, then Fold::prepare
-      will have retrieved an ephemeris, and the DM from this ephemeris 
+      will have retrieved an ephemeris, and the DM from this ephemeris
       should make its way into the folded profile.
     */
     const Pulsar::Parameters* ephem = fold[ifold]->get_pulsar_ephemeris ();
     change->set_dispersion_measure( get_dispersion_measure(ephem) );
   }
-  
+
   // fold[ifold]->reset();
-    
+
   if (config->asynchronous_fold)
     asynch_fold[ifold] = new OperationThread( fold[ifold].get() );
   else
     operations.push_back( fold[ifold].get() );
-  
+
 #if HAVE_CUDA
   if (gpu_stream != undefined_stream)
   {
@@ -1243,10 +1254,10 @@ void dsp::LoadToFold::prepare_archiver( Archiver* archiver )
 
   if (output_subints() && config->subints_per_archive)
   {
-    cerr << "dspsr: Archives with " << 
+    cerr << "dspsr: Archives with " <<
         config->subints_per_archive << " sub-integrations" << endl;
     archiver->set_use_single_archive (true);
-    archiver->set_subints_per_file (config->subints_per_archive); 
+    archiver->set_subints_per_file (config->subints_per_archive);
   }
 
   if (config->integration_turns || config->no_dynamic_extensions)
@@ -1264,7 +1275,7 @@ void dsp::LoadToFold::prepare_archiver( Archiver* archiver )
       archiver->set_convention( epoch_convention = new FilenameEpoch );
 
     // If archive_filename was specified, figure out whether
-    // it represents a date string or not by looking for '%' 
+    // it represents a date string or not by looking for '%'
     // characters.
     else if (!config->archive_filename.empty())
     {
@@ -1279,7 +1290,7 @@ void dsp::LoadToFold::prepare_archiver( Archiver* archiver )
       archiver->set_convention( epoch_convention = new FilenameEpoch );
   }
 
-  if (epoch_convention && output_subints() 
+  if (epoch_convention && output_subints()
       && (config->single_archive || config->subints_per_archive))
     epoch_convention->report_unload = false;
 
@@ -1315,13 +1326,13 @@ void dsp::LoadToFold::prepare_archiver( Archiver* archiver )
 
   if (sample_delay)
     archiver->set_archive_dedispersed (true);
-  
+
   if (config->jobs.size())
     archiver->set_script (config->jobs);
-  
+
   if (fold.size() > 1)
     archiver->set_path_add_source (true);
-  
+
   if (!config->archive_extension.empty())
     archiver->set_extension (config->archive_extension);
 
@@ -1382,7 +1393,7 @@ void dsp::LoadToFold::run ()
   if (log)
     for (unsigned iul=0; iul < unloader.size(); iul++)
       unloader[iul]->set_cerr (*log);
-  
+
   SingleThread::run ();
 }
 
@@ -1430,4 +1441,3 @@ catch (Error& error)
 {
   throw error += "dsp::LoadToFold::finish";
 }
-

--- a/Signal/Pulsar/LoadToFoldConfig.C
+++ b/Signal/Pulsar/LoadToFoldConfig.C
@@ -14,6 +14,9 @@ dsp::LoadToFold::Config::Config ()
   can_cuda = true;
   can_thread = true;
 
+  // useful for gpu filterbank
+  input_stream = (void*) 0;
+
   minimum_RAM = 0;
   maximum_RAM = 256 * 1024 * 1024;
   times_minimum_ndat = 1;

--- a/Signal/Pulsar/dsp/LoadToFoldConfig.h
+++ b/Signal/Pulsar/dsp/LoadToFoldConfig.h
@@ -43,6 +43,9 @@ namespace dsp {
     //! Default constructor
     Config ();
 
+    // useful for gpu filterbank
+    void* input_stream;
+
     // set block size to this factor times the minimum possible
     void set_times_minimum_ndat (unsigned);
     unsigned get_times_minimum_ndat () const { return times_minimum_ndat; }

--- a/Signal/Pulsar/dsp/LoadToFoldConfig.h
+++ b/Signal/Pulsar/dsp/LoadToFoldConfig.h
@@ -45,6 +45,7 @@ namespace dsp {
 
     // useful for gpu filterbank
     void* input_stream;
+    void* d_kernel_gpu;
 
     // set block size to this factor times the minimum possible
     void set_times_minimum_ndat (unsigned);


### PR DESCRIPTION
It's still buggy, but the ability to set nbundle is in place, and the code (generally) runs from beginning to end and I'm pretty sure it doesn't corrupt data.  This makes it possible to run MANY-channel input (for CHIME it's 1024 input channels) in subsets of channels (eg, channels 0-7, then 8-15, then 16-23, ...) allowing for more time samples to be loaded to GPU at once and thus longer FFTs to be performed.  In its current form, unpacking on the CPU is the biggest bottleneck.  I'm having each thread unpack a complete set of frequency channels, then transfer to GPU etc in bundles until it returns to bundle 0 and unpacks some more.  Since streams are launched simultaneously, they all unpack at once which slows down the unpacking, then they all compute at once while no unpacking happens.  The unpacking being staggered between threads would solve or largely solve this problem.
